### PR TITLE
Generalize annotation support with actions

### DIFF
--- a/src/pegen/metagrammar.gram
+++ b/src/pegen/metagrammar.gram
@@ -57,8 +57,7 @@ rule[Rule]:
     | rulename memoflag? ":" alts NEWLINE { Rule(rulename[0], rulename[1], alts, memo=opt) }
 
 rulename[RuleName]:
-    | NAME '[' type=NAME '*' ']' { (name.string, type.string+"*") }
-    | NAME '[' type=NAME ']' { (name.string, type.string) }
+    | NAME annotation { (name.string, annotation) }
     | NAME { (name.string, None) }
 
 # In the future this may return something more complicated
@@ -84,8 +83,7 @@ items[NamedItemList]:
     | named_item { [named_item] }
 
 named_item[NamedItem]:
-    | NAME '[' type=NAME '*' ']' '=' ~ item {NamedItem(name.string, item, f"{type.string}*")}
-    | NAME '[' type=NAME ']' '=' ~ item {NamedItem(name.string, item, type.string)}
+    | NAME annotation '=' ~ item {NamedItem(name.string, item, annotation)}
     | NAME '=' ~ item {NamedItem(name.string, item)}
     | item {NamedItem(None, item)}
     | it=forced_atom {NamedItem(None, it)}
@@ -112,19 +110,22 @@ atom[Plain]:
     | NAME {NameLeaf(name.string) }
     | STRING {StringLeaf(string.string)}
 
-# Mini-grammar for the actions
+# Mini-grammar for the actions and annotations
 
 action[str]: "{" ~ target_atoms "}" { target_atoms }
+annotation[str]: "[" ~ target_atoms "]" { target_atoms }
 
 target_atoms[str]:
     | target_atom target_atoms { target_atom + " " + target_atoms }
     | target_atom { target_atom }
 
 target_atom[str]:
-    | "{" ~ target_atoms "}" { "{" + target_atoms + "}" }
+    | "{" ~ atoms=target_atoms? "}" { "{" + (atoms or "") + "}" }
+    | "[" ~ atoms=target_atoms? "]" { "[" + (atoms or "") + "]" }
+    | NAME "*" { name.string + "*" }
     | NAME { name.string }
     | NUMBER { number.string }
     | STRING { string.string }
     | "?" { "?" }
     | ":" { ":" }
-    | !"}" OP { op.string }
+    | !"}" !"]" OP { op.string }

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -33,6 +33,7 @@ def test_parse_grammar() -> None:
     expected_repr = "Rule('term', None, Rhs([Alt([NamedItem(None, NameLeaf('NUMBER'))])]))"
     assert repr(rules["term"]) == expected_repr
 
+
 def test_parse_grammar_with_types() -> None:
     grammar = """
     start[ast.BinOp]: term ('+' term)* NEWLINE
@@ -45,6 +46,7 @@ def test_parse_grammar_with_types() -> None:
     assert rules["start"].type.replace(" ", "") == "ast.BinOp"
     assert rules["term"].type.replace(" ", "") == "T[int]"
     assert rules["c_rule"].type == "expr_ty*"
+
 
 def test_long_rule_str() -> None:
     grammar_source = """

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -33,6 +33,18 @@ def test_parse_grammar() -> None:
     expected_repr = "Rule('term', None, Rhs([Alt([NamedItem(None, NameLeaf('NUMBER'))])]))"
     assert repr(rules["term"]) == expected_repr
 
+def test_parse_grammar_with_types() -> None:
+    grammar = """
+    start[ast.BinOp]: term ('+' term)* NEWLINE
+    term[T[int]]: NUMBER
+    c_rule[expr_ty*]: a=NUMBER? { _new_expr_ty(a) }
+    """
+
+    grammar: Grammar = parse_string(grammar, GrammarParser)
+    rules = grammar.rules
+    assert rules["start"].type.replace(" ", "") == "ast.BinOp"
+    assert rules["term"].type.replace(" ", "") == "T[int]"
+    assert rules["c_rule"].type == "expr_ty*"
 
 def test_long_rule_str() -> None:
     grammar_source = """


### PR DESCRIPTION
Currently for annotations we can only use either a normal name (like `expr`) or a name followed by star (`expr_ty*`), though at least for python, type annotations are a bit more broad. Some examples;

```
start[ast.mod]: statements
strings[List[str]]: STRING+
```
These are currently unsupported, so what this PR does is actually unifies the annotation syntax with the mini-action grammar. And opens up the possibility of the using any sort of expression as types (also includes a little bugfix that allows you to create empty dictionary on the action part)