### PR TITLE
Do not format subheader

### DIFF
--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -145,7 +145,7 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
             self.print(header.rstrip("\n").format(filename=filename))
         subheader = self.grammar.metas.get("subheader", "")
         if subheader:
-            self.print(subheader.format(filename=filename))
+            self.print(subheader)
         cls_name = self.grammar.metas.get("class", "GeneratedParser")
         self.print(f"class {cls_name}(Parser):")
         while self.todo:


### PR DESCRIPTION
This allows to use Python formatting based on curly braces without having to double all curly braces.