### PR TITLE
Format the trailer section with the parser class name 

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -155,6 +155,8 @@ can add dedicated sections to the grammar, which are discussed below:
 
   Specify a trailer for the module which is appended to the parser definition.
   It defaults to MODULE_SUFFIX which is defined in pegen.python_generator.
+  Note that the trailer is formatted using `.format(class_name=cls_name)`
+  allowing you to reference the created parser in the trailer.
 
 
 The following snippets illustrates naming the parser MyParser and making the

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -41,7 +41,7 @@ MODULE_SUFFIX = """
 
 if __name__ == '__main__':
     from pegen.parser import simple_parser_main
-    simple_parser_main(GeneratedParser)
+    simple_parser_main({class_name})
 """
 
 
@@ -172,7 +172,7 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
             self.print(f"KEYWORDS = {tuple(self.callmakervisitor.keywords)}")
             self.print(f"SOFT_KEYWORDS = {tuple(self.callmakervisitor.soft_keywords)}")
 
-        trailer = self.grammar.metas.get("trailer", MODULE_SUFFIX)
+        trailer = self.grammar.metas.get("trailer", MODULE_SUFFIX.format(class_name=cls_name))
         if trailer is not None:
             self.print(trailer.rstrip("\n"))
 


### PR DESCRIPTION
The use of non default name leads to a broken `if __name__ == __main__` section before this patch.