### PR TITLE
Add a special SOFT_KEYWORD rule allowing to match any soft keyword

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -101,6 +101,18 @@ alternative won't be considered, even if some_rule or ')' fail
 to be parsed.
 
 
+### Keywords
+
+Keywords are identified in the grammar as quoted names. Single quotes `'def'`
+are used to identify hard keywords i.e. keywords that are reserved in the grammar
+and cannot be used for any other purpose. Double quotes `"match"` identify
+soft keywords that act as keyword only in specific context. As a consequence a
+rule matching `NAME` may match a soft keyword but never a hard keyword.
+
+In some circonstances, it can desirable to match any soft keyword for those cases
+one can use `SOFT_KEYWORD` that will expand to `"match" | "case"` if `match` and
+`case` are the only two known soft keywords.
+
 ### Return Value
 
 Optionally, an alternative can be followed by a so-called action

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -212,6 +212,13 @@ class Parser:
         return None
 
     @memoize
+    def soft_keyword(self) -> Optional[tokenize.TokenInfo]:
+        tok = self._tokenizer.peek()
+        if tok.type == token.NAME and tok.string in self.SOFT_KEYWORDS:
+            return self._tokenizer.getnext()
+        return None
+
+    @memoize
     def expect(self, type: str) -> Optional[tokenize.TokenInfo]:
         tok = self._tokenizer.peek()
         if tok.string == type:

--- a/src/pegen/parser_generator.py
+++ b/src/pegen/parser_generator.py
@@ -18,12 +18,12 @@ from pegen.grammar import (
 
 
 class RuleCheckingVisitor(GrammarVisitor):
-    def __init__(self, rules: Dict[str, Rule], tokens: Dict[int, str]):
+    def __init__(self, rules: Dict[str, Rule], tokens: Set[str]):
         self.rules = rules
         self.tokens = tokens
 
     def visit_NameLeaf(self, node: NameLeaf) -> None:
-        if node.value not in self.rules and node.value not in self.tokens.values():
+        if node.value not in self.rules and node.value not in self.tokens:
             # TODO: Add line/col info to (leaf) nodes
             raise GrammarError(f"Dangling reference to rule {node.value!r}")
 
@@ -37,7 +37,7 @@ class ParserGenerator:
 
     callmakervisitor: GrammarVisitor
 
-    def __init__(self, grammar: Grammar, tokens: Dict[int, str], file: Optional[IO[Text]]):
+    def __init__(self, grammar: Grammar, tokens: Set[str], file: Optional[IO[Text]]):
         self.grammar = grammar
         self.tokens = tokens
         self.rules = grammar.rules

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -54,6 +54,8 @@ class PythonCallMakerVisitor(GrammarVisitor):
 
     def visit_NameLeaf(self, node: NameLeaf) -> Tuple[Optional[str], str]:
         name = node.value
+        if name == "SOFT_KEYWORD":
+            return "soft_keyword", "self.soft_keyword()"
         if name in ("NAME", "NUMBER", "STRING", "OP", "TYPE_COMMENT"):
             name = name.lower()
             return name, f"self.{name}()"
@@ -145,8 +147,9 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
         self,
         grammar: grammar.Grammar,
         file: Optional[IO[Text]],
-        tokens: Dict[int, str] = token.tok_name,
+        tokens: Set[str] = set(token.tok_name.values()),
     ):
+        tokens.add("SOFT_KEYWORD")
         super().__init__(grammar, tokens, file)
         self.callmakervisitor: PythonCallMakerVisitor = PythonCallMakerVisitor(self)
 

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -562,8 +562,13 @@ def test_soft_keyword() -> None:
     grammar = """
     start:
         | "number" n=NUMBER { eval(n.string) }
-        | !(SOFT_KEYWORD) l=NAME n=NUMBER { f"{l.string} = {n.string}"}
+        | "string" n=STRING { n.string }
+        | SOFT_KEYWORD l=NAME n=(NUMBER | NAME | STRING) { f"{l.string} = {n.string}"}
     """
     parser_class = make_parser(grammar)
     assert parse_string("number 1", parser_class, verbose=True) == 1
-    assert parse_string("test 1", parser_class, verbose=True) == "test = 1"
+    assert parse_string("string 'b'", parser_class, verbose=True) == "'b'"
+    assert parse_string("number test 1", parser_class, verbose=True) == "test = 1"
+    assert parse_string("string test 'b'", parser_class, verbose=True) == "test = 'b'"
+    with pytest.raises(SyntaxError):
+        parse_string("test 1", parser_class, verbose=True)

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -556,3 +556,14 @@ def test_missing_start() -> None:
     """
     with pytest.raises(GrammarError):
         parser_class = make_parser(grammar)
+
+
+def test_soft_keyword() -> None:
+    grammar = """
+    start:
+        | "number" n=NUMBER { eval(n.string) }
+        | !(SOFT_KEYWORD) l=NAME n=NUMBER { f"{l.string} = {n.string}"}
+    """
+    parser_class = make_parser(grammar)
+    assert parse_string("number 1", parser_class, verbose=True) == 1
+    assert parse_string("test 1", parser_class, verbose=True) == "test = 1"


### PR DESCRIPTION
This is used once in the Python parser for error reporting.