### PR TITLE
Add support for Forced grammar node in the parser generator

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -61,18 +61,18 @@ rule_name: e (',' e)* [',']
 ```
 
 ##### `e*`
-Match zero or more occurences of e.
+Match zero or more occurrences of e.
 ```
 rule_name: (e1 e2)*
 ```
 
 ##### `e+`
-Match one or more occurences of e.
+Match one or more occurrences of e.
 ```
 rule_name: (e1 e2)+
 ```
 ##### `s.e+`
-Match one or more occurences of e, separated by s. The generated parse tree
+Match one or more occurrences of e, separated by s. The generated parse tree
 does not include the separator. This is identical to `(e (s e)*)`.
 ```
 rule_name: ','.e+
@@ -99,6 +99,12 @@ rule_name: '(' ~ some_rule ')' | some_alt
 In this example, if a left parenthesis is parsed, then the other
 alternative won't be considered, even if some_rule or ')' fail
 to be parsed.
+
+##### `&&e`
+Fail immediatly if e fails to parse by raising the exception built using the
+`make_syntax_error` method.
+
+This construct can help provides better error messages.
 
 
 ### Keywords

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -240,6 +240,12 @@ class Parser:
             return self._tokenizer.getnext()
         return None
 
+    def expect_forced(self, type: str) -> Optional[tokenize.TokenInfo]:
+        res = self.expect(type)
+        if res is None:
+            raise self.make_syntax_error(f"expected '{type}'")
+        return res
+
     def positive_lookahead(self, func: Callable[..., T], *args: object) -> T:
         mark = self._mark()
         ok = func(*args)
@@ -252,11 +258,9 @@ class Parser:
         self._reset(mark)
         return not ok
 
-    def make_syntax_error(self, filename: str = "<unknown>") -> SyntaxError:
+    def make_syntax_error(self, message: str, filename: str = "<unknown>") -> SyntaxError:
         tok = self._tokenizer.diagnose()
-        return SyntaxError(
-            "pegen parse failure", (filename, tok.start[0], 1 + tok.start[1], tok.line)
-        )
+        return SyntaxError(message, (filename, tok.start[0], 1 + tok.start[1], tok.line))
 
 
 def simple_parser_main(parser_class: Type[Parser]) -> None:

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -240,10 +240,9 @@ class Parser:
             return self._tokenizer.getnext()
         return None
 
-    def expect_forced(self, type: str) -> Optional[tokenize.TokenInfo]:
-        res = self.expect(type)
+    def expect_forced(self, res: Any, expectation: str) -> Optional[tokenize.TokenInfo]:
         if res is None:
-            raise self.make_syntax_error(f"expected '{type}'")
+            raise self.make_syntax_error(f"expected {expectation}")
         return res
 
     def positive_lookahead(self, func: Callable[..., T], *args: object) -> T:

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -143,8 +143,14 @@ class PythonCallMakerVisitor(GrammarVisitor):
         return "cut", "True"
 
     def visit_Forced(self, node: Forced) -> Tuple[str, str]:
-        val = ast.literal_eval(node.node.value)
-        return "literal", f"self.expect_forced({node.node.value})"
+        if isinstance(node.node, Group):
+            _, val = self.visit(node.node.rhs)
+            return "forced", f"self.expect_forced({val}, '''({node.node.rhs!s})''')"
+        else:
+            return (
+                "forced",
+                f"self.expect_forced(self.expect({node.node.value}), {node.node.value!r})",
+            )
 
 
 class PythonParserGenerator(ParserGenerator, GrammarVisitor):

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -7,6 +7,7 @@ from pegen import grammar
 from pegen.grammar import (
     Alt,
     Cut,
+    Forced,
     Gather,
     GrammarVisitor,
     Group,
@@ -140,6 +141,10 @@ class PythonCallMakerVisitor(GrammarVisitor):
 
     def visit_Cut(self, node: Cut) -> Tuple[str, str]:
         return "cut", "True"
+
+    def visit_Forced(self, node: Forced) -> Tuple[str, str]:
+        val = ast.literal_eval(node.node.value)
+        return "literal", f"self.expect_forced({node.node.value})"
 
 
 class PythonParserGenerator(ParserGenerator, GrammarVisitor):

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -584,7 +584,7 @@ def test_soft_keyword() -> None:
     with pytest.raises(SyntaxError):
         parse_string("test 1", parser_class, verbose=True)
 
-        
+
 def test_forced() -> None:
     grammar = """
     start: NAME &&':' | NAME

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -597,7 +597,7 @@ def test_forced() -> None:
     assert "expected ':'" in str(e.exconly())
 
 
-def test_forced() -> None:
+def test_forced_with_group() -> None:
     grammar = """
     start: NAME &&(':' | ';') | NAME
     """

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -590,7 +590,21 @@ def test_forced() -> None:
     start: NAME &&':' | NAME
     """
     parser_class = make_parser(grammar)
+    assert parse_string("number :", parser_class, verbose=True)
     with pytest.raises(SyntaxError) as e:
         parse_string("a", parser_class, verbose=True)
 
     assert "expected ':'" in str(e.exconly())
+
+
+def test_forced() -> None:
+    grammar = """
+    start: NAME &&(':' | ';') | NAME
+    """
+    parser_class = make_parser(grammar)
+    assert parse_string("number :", parser_class, verbose=True)
+    assert parse_string("number ;", parser_class, verbose=True)
+    with pytest.raises(SyntaxError) as e:
+        parse_string("a", parser_class, verbose=True)
+
+    assert "expected (':' | ';')" in e.value.args[0]

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -583,3 +583,14 @@ def test_soft_keyword() -> None:
     assert parse_string("string test 'b'", parser_class, verbose=True) == "test = 'b'"
     with pytest.raises(SyntaxError):
         parse_string("test 1", parser_class, verbose=True)
+
+        
+def test_forced() -> None:
+    grammar = """
+    start: NAME &&':' | NAME
+    """
+    parser_class = make_parser(grammar)
+    with pytest.raises(SyntaxError) as e:
+        parse_string("a", parser_class, verbose=True)
+
+    assert "expected ':'" in str(e.exconly())

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,7 @@ def run_parser(file: IO[bytes], parser_class: Type[Parser], *, verbose: bool = F
     parser = parser_class(tokenizer, verbose=verbose)
     result = parser.start()
     if result is None:
-        raise parser.make_syntax_error()
+        raise parser.make_syntax_error("invalid syntax")
     return result
 
 


### PR DESCRIPTION
If the parsing fails, we immediately raise an error built using `make_syntax_error`