### PR TITLE
python.gram: fix handling of legacy expression and add tests

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -1624,6 +1624,7 @@ invalid_legacy_expression:
         None
      }
 invalid_expression[NoReturn]:
+    | invalid_legacy_expression
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
     | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -42,6 +42,9 @@ def test_syntax_error_in_str(python_parse_file, python_parse_str, tmp_path, sour
         ("2 if 4", "expected 'else' after 'if' expression"),
         ("a 1 if b else 2", "invalid syntax. Perhaps you forgot a comma?"),
         ("a 1ambda: 1", "invalid syntax. Perhaps you forgot a comma?"),
+        ("print 1", "Missing parentheses in call to 'print'"),
+        ("exec 1", "Missing parentheses in call to 'exec'"),
+        ("a if b", "expected 'else' after 'if' expression"),
     ],
 )
 def test_invalid_expression(python_parse_file, python_parse_str, tmp_path, source, message):


### PR DESCRIPTION
Add the missing tests for the new error rules and add a missing entry in invalid_expression to actually use invalid_legacy_expression