### PR TITLE
python.gram: stricter rule for trailing comma in import

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -1753,7 +1753,7 @@ invalid_group[NoReturn]:
         self.raise_syntax_error_known_location("cannot use double starred expression here", a)
      }
 invalid_import_from_targets[NoReturn]:
-    | import_from_as_names ',' {
+    | import_from_as_names ',' NEWLINE {
         self.raise_syntax_error("trailing comma not allowed without surrounding parentheses")
      }
 

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -289,6 +289,7 @@ def test_invalid_group(python_parse_file, python_parse_str, tmp_path, source, me
     "source, message",
     [
         ("from a import b,", "trailing comma not allowed without surrounding parentheses"),
+        ("from a import b, and 3", "invalid syntax"),
         ("from a import raise", "invalid syntax"),
     ],
 )


### PR DESCRIPTION
cf https://github.com/python/cpython/commit/b2f68b190035540872072ac1d2349e7745e85596