### PR TITLE
Sort KEYWORDS for consistent output ordering

### DIFF
--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -237,8 +237,8 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
 
         self.print()
         with self.indent():
-            self.print(f"KEYWORDS = {tuple(self.callmakervisitor.keywords)}")
-            self.print(f"SOFT_KEYWORDS = {tuple(self.callmakervisitor.soft_keywords)}")
+            self.print(f"KEYWORDS = {tuple(sorted(self.callmakervisitor.keywords))}")
+            self.print(f"SOFT_KEYWORDS = {tuple(sorted(self.callmakervisitor.soft_keywords))}")
 
         trailer = self.grammar.metas.get("trailer", MODULE_SUFFIX.format(class_name=cls_name))
         if trailer is not None:

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -683,10 +683,11 @@ def test_locations_in_alt_action_and_group() -> None:
         print(diff)
     assert not diff
 
+
 def test_keywords() -> None:
     grammar = """
     start: 'one' 'two' 'three' 'four' 'five' "six" "seven" "eight" "nine" "ten"
     """
     parser_class = make_parser(grammar)
-    assert parser_class.KEYWORDS == ('five', 'four', 'one', 'three', 'two')
-    assert parser_class.SOFT_KEYWORDS == ('eight', 'nine', 'seven', 'six', 'ten')
+    assert parser_class.KEYWORDS == ("five", "four", "one", "three", "two")
+    assert parser_class.SOFT_KEYWORDS == ("eight", "nine", "seven", "six", "ten")

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -682,3 +682,11 @@ def test_locations_in_alt_action_and_group() -> None:
     if diff:
         print(diff)
     assert not diff
+
+def test_keywords() -> None:
+    grammar = """
+    start: 'one' 'two' 'three' 'four' 'five' "six" "seven" "eight" "nine" "ten"
+    """
+    parser_class = make_parser(grammar)
+    assert parser_class.KEYWORDS == ('five', 'four', 'one', 'three', 'two')
+    assert parser_class.SOFT_KEYWORDS == ('eight', 'nine', 'seven', 'six', 'ten')


### PR DESCRIPTION
Fixes #40 by adding `sorted(...)` as suggested previously.

I could use some guidance for writing tests.