### PR TITLE
python.gram: SyntaxError column numbers to match cpython 3.10

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -1580,10 +1580,10 @@ invalid_arguments[NoReturn]:
             "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b
         )
      }
-    | a=args for_if_clauses {
-        self.store_syntax_error_starting_from(
+    | a=args b=for_if_clauses {
+        self.store_syntax_error_known_range(
             "Generator expression must be parenthesized",
-            a[1][-1] if a[1] else a[0][-1]
+            a[1][-1] if a[1] else a[0][-1], b
         )
      }
     | args ',' a=expression b=for_if_clauses {

--- a/data/python.gram
+++ b/data/python.gram
@@ -303,10 +303,10 @@ class Parser(Parser):
                 self._tokenizer.get_lines(list(range(start[0], end[0] + 1)))
             )
 
-        self._exception = SyntaxError(
-            message,
-            (self.filename, start[0], start[1], line)
-        )
+        args = (self.filename, start[0], start[1], line)
+        if sys.version_info >= (3, 10):
+            args += (stop[0], stop[1])
+        self._exception = SyntaxError(message, args)
 
     def store_syntax_error(self, message: str) -> None:
         self._store_syntax_error(message)

--- a/data/python.gram
+++ b/data/python.gram
@@ -303,9 +303,9 @@ class Parser(Parser):
                 self._tokenizer.get_lines(list(range(start[0], end[0] + 1)))
             )
 
-        args = (self.filename, start[0], start[1], line)
+        args = (self.filename, start[0], start[1]+1, line)
         if sys.version_info >= (3, 10):
-            args += (end[0], end[1])
+            args += (end[0], end[1]+1)
         self._exception = SyntaxError(message, args)
 
     def store_syntax_error(self, message: str) -> None:

--- a/data/python.gram
+++ b/data/python.gram
@@ -305,7 +305,7 @@ class Parser(Parser):
 
         args = (self.filename, start[0], start[1], line)
         if sys.version_info >= (3, 10):
-            args += (stop[0], stop[1])
+            args += (end[0], end[1])
         self._exception = SyntaxError(message, args)
 
     def store_syntax_error(self, message: str) -> None:

--- a/data/python.gram
+++ b/data/python.gram
@@ -1583,7 +1583,8 @@ invalid_arguments[NoReturn]:
     | a=args b=for_if_clauses {
         self.store_syntax_error_known_range(
             "Generator expression must be parenthesized",
-            a[1][-1] if a[1] else a[0][-1], b
+            a[1][-1] if a[1] else a[0][-1],
+            b[-1].ifs[-1] if b[-1].ifs else b[-1].iter
         )
      }
     | args ',' a=expression b=for_if_clauses {

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -24,8 +24,8 @@ def parse_invalid_syntax(
     with pytest.raises(exc_cls) as e:
         python_parse_file(str(test_file))
 
-    print(str( e.exconly()))
-    assert message in str( e.exconly())
+    print(str(e.exconly()))
+    assert message in str(e.exconly())
 
     exc = e.value
     if start:
@@ -116,8 +116,18 @@ def test_invalid_statements(python_parse_file, python_parse_str, tmp_path, sourc
         ("f(**a, b)", "positional argument follows keyword argument unpacking", None, None),
         ("f(a=1, b)", "positional argument follows keyword argument", None, None),
         # Invalid kwarg rules
-        ("f(b=c for c in d)", "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", None, None),
-        ("f(1 + b=2)", 'expression cannot contain assignment, perhaps you meant "=="?', None, None),
+        (
+            "f(b=c for c in d)",
+            "invalid syntax. Maybe you meant '==' or ':=' instead of '='?",
+            None,
+            None,
+        ),
+        (
+            "f(1 + b=2)",
+            'expression cannot contain assignment, perhaps you meant "=="?',
+            None,
+            None,
+        ),
     ],
 )
 def test_invalid_call_arguments(

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -29,25 +29,38 @@ def parse_invalid_syntax(
 
     exc = e.value
     if start:
-        assert (exc.lineno, exc.offset) == (start[0], start[1]), f"expected start location of {start} but got {(exc.lineno, exc.offset)}"
+        assert (exc.lineno, exc.offset) == (
+            start[0],
+            start[1],
+        ), f"expected start location of {start} but got {(exc.lineno, exc.offset)}"
     else:
-        assert exc.lineno is None and exc.offset is None, f"missing start location ({exc.lineno}, {exc.offset})" + f" xxx ({exc.end_lineno}, {exc.end_offset})"
+        assert exc.lineno is None and exc.offset is None, (
+            f"missing start location ({exc.lineno}, {exc.offset})"
+            + f" xxx ({exc.end_lineno}, {exc.end_offset})"
+        )
 
     if sys.version_info >= (3, 10):
         if end:
-            assert (exc.end_lineno, exc.end_offset) == (end[0], end[1]), f"expected end location of {end} but got {(exc.end_lineno, exc.end_offset)}"
+            assert (exc.end_lineno, exc.end_offset) == (
+                end[0],
+                end[1],
+            ), f"expected end location of {end} but got {(exc.end_lineno, exc.end_offset)}"
         else:
-            assert exc.end_lineno is None and exc.end_offset is None, f"missing end location ({exc.end_lineno}, {exc.end_offset})"
+            assert (
+                exc.end_lineno is None and exc.end_offset is None
+            ), f"missing end location ({exc.end_lineno}, {exc.end_offset})"
 
 
 @pytest.mark.parametrize(
     "source, message, start, end",
     [
-      ("f'a = { 1 + }'", "line 1", (1, 1), (1, 15)),
-      ("(\n\t'b'\n\tf'a = { 1 + }'\n)", "line 3", (3, 2), (3, 16))
+        ("f'a = { 1 + }'", "line 1", (1, 1), (1, 15)),
+        ("(\n\t'b'\n\tf'a = { 1 + }'\n)", "line 3", (3, 2), (3, 16)),
     ],
 )
-def test_syntax_error_in_str(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_syntax_error_in_str(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -66,7 +79,9 @@ def test_syntax_error_in_str(python_parse_file, python_parse_str, tmp_path, sour
         ("c = a if b:", "SyntaxError: invalid syntax", (None, None), (None, None)),
     ],
 )
-def test_invalid_expression(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_expression(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -154,17 +169,47 @@ def test_invalid_call_arguments(
         ("False = 1", "cannot assign to False", (1, 1), (1, 6)),
         ("... = 1", "cannot assign to Ellipsis", (1, 1), (1, 4)),
         ("None = 1", "cannot assign to None", (1, 1), (1, 5)),
-        ("(a, b) : int = (1, 2)", "only single target (not tuple) can be annotated", (1, 1), (1, 7)),
-        ("[a, b] : int = [1, 2]", "only single target (not list) can be annotated", (1, 1), (1, 7)),
-        ("([a, b]) : int = (1, 2)", "only single target (not list) can be annotated", (1, 2), (1, 8)),
-        ("a, b: int, int = 1, 2", "only single target (not tuple) can be annotated", (1, 1), (1, 2)),
+        (
+            "(a, b) : int = (1, 2)",
+            "only single target (not tuple) can be annotated",
+            (1, 1),
+            (1, 7),
+        ),
+        (
+            "[a, b] : int = [1, 2]",
+            "only single target (not list) can be annotated",
+            (1, 1),
+            (1, 7),
+        ),
+        (
+            "([a, b]) : int = (1, 2)",
+            "only single target (not list) can be annotated",
+            (1, 2),
+            (1, 8),
+        ),
+        (
+            "a, b: int, int = 1, 2",
+            "only single target (not tuple) can be annotated",
+            (1, 1),
+            (1, 2),
+        ),
         ("{a, b} : set", "illegal target for annotation", (1, 1), (1, 7)),
         ("a + 1 = 2", "cannot assign to expression", (1, 1), (1, 6)),
         ("[i for i in range(2)] = 2", "cannot assign to list comprehension", (1, 1), (1, 22)),
         ("yield a = 1", "assignment to yield expression not possible", (1, 1), (1, 8)),
         ("a = yield b = 1", "assignment to yield expression not possible", (1, 5), (1, 12)),
-        ("a + 1 += 1", "expression is an illegal expression for augmented assignment", (1, 1), (1, 6)),
-        ("a + 1 += yield", "expression is an illegal expression for augmented assignment", (1, 1), (1, 6)),
+        (
+            "a + 1 += 1",
+            "expression is an illegal expression for augmented assignment",
+            (1, 1),
+            (1, 6),
+        ),
+        (
+            "a + 1 += yield",
+            "expression is an illegal expression for augmented assignment",
+            (1, 1),
+            (1, 6),
+        ),
         (
             "[i for i in range(2)] += 1",
             "list comprehension is an illegal expression for augmented assignment",
@@ -174,7 +219,9 @@ def test_invalid_call_arguments(
         ("a += raise", "invalid syntax", (None, None), (None, None)),
     ],
 )
-def test_invalid_assignments(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_assignments(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -187,7 +234,9 @@ def test_invalid_assignments(python_parse_file, python_parse_str, tmp_path, sour
         ("del a + 1", "cannot delete expression", (1, 5), (1, 10)),
     ],
 )
-def test_invalid_del_statements(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_del_statements(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -199,45 +248,59 @@ def test_invalid_del_statements(python_parse_file, python_parse_str, tmp_path, s
         (
             "(*a for a in enumerate(range(5)))",
             "iterable unpacking cannot be used in comprehension",
-            (1, 2), (1, 4),
+            (1, 2),
+            (1, 4),
         ),
         (
             "[*a for a in enumerate(range(5))]",
             "iterable unpacking cannot be used in comprehension",
-            (1, 2), (1, 4),
+            (1, 2),
+            (1, 4),
         ),
         (
             "{*a for a in enumerate(range(5))}",
             "iterable unpacking cannot be used in comprehension",
-            (1, 2), (1, 4),
+            (1, 2),
+            (1, 4),
         ),
         (
             "[a, a for a in range(5)]",
             "did you forget parentheses around the comprehension target?",
-            (1, 2), (1, 6),
+            (1, 2),
+            (1, 6),
         ),
         (
             "[a, a for a in range(5)]",
             "did you forget parentheses around the comprehension target?",
-            (1, 2), (1, 6),
+            (1, 2),
+            (1, 6),
         ),
         (
             "[a,  for a in range(5)]",
             "did you forget parentheses around the comprehension target?",
-            (1, 2), (1, 4),
+            (1, 2),
+            (1, 4),
         ),
         (
             "[a,  for a in range(5)]",
             "did you forget parentheses around the comprehension target?",
-            (1, 2), (1, 4),
+            (1, 2),
+            (1, 4),
         ),
-        ("{**a for a in [{1: 2}]}", "dict unpacking cannot be used in dict comprehension", (1, 2), (1, 4)),
+        (
+            "{**a for a in [{1: 2}]}",
+            "dict unpacking cannot be used in dict comprehension",
+            (1, 2),
+            (1, 4),
+        ),
         # check cuts
         ("(a for a in raise)", "invalid syntax", (None, None), (None, None)),
         ("(a async for a in raise)", "invalid syntax", (None, None), (None, None)),
     ],
 )
-def test_invalid_comprehension(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_comprehension(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -296,7 +359,9 @@ def test_invalid_star_etc(python_parse_file, python_parse_str, tmp_path, source,
         ("with open(a) as 1:\n\tpass", "cannot assign to 1", (1, 17), (1, 18)),
     ],
 )
-def test_invalid_with_item(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_with_item(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -309,7 +374,9 @@ def test_invalid_with_item(python_parse_file, python_parse_str, tmp_path, source
         ("async for (a := i)", "cannot assign to named expression", (1, 12), (1, 18)),
     ],
 )
-def test_invalid_for_target(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_invalid_for_target(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -322,7 +389,9 @@ def test_invalid_for_target(python_parse_file, python_parse_str, tmp_path, sourc
         ("a := raise", "invalid syntax", (None, None), (None, None)),
     ],
 )
-def test_named_expression(python_parse_file, python_parse_str, tmp_path, source, message, start, end):
+def test_named_expression(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end
+):
     parse_invalid_syntax(
         python_parse_file, python_parse_str, tmp_path, source, SyntaxError, message, start, end
     )
@@ -344,7 +413,12 @@ def test_invalid_group(python_parse_file, python_parse_str, tmp_path, source, me
 @pytest.mark.parametrize(
     "source, message, start, end",
     [
-        ("from a import b,", "trailing comma not allowed without surrounding parentheses", (1, 17), (1, 18)),
+        (
+            "from a import b,",
+            "trailing comma not allowed without surrounding parentheses",
+            (1, 17),
+            (1, 18),
+        ),
         ("from a import b, and 3", "invalid syntax", (None, None), (None, None)),
         ("from a import raise", "invalid syntax", (None, None), (None, None)),
     ],
@@ -375,13 +449,21 @@ def test_invalid_import_from_as_names(
             None,
         ),
         ("with open(a) as f, b as d\npass", SyntaxError, "expected ':'", (1, 26), (1, 27)),
-        ("\nasync with (open(a) as f, b as d)\npass", SyntaxError, "expected ':'", (2, 34), (2, 35)),
+        (
+            "\nasync with (open(a) as f, b as d)\npass",
+            SyntaxError,
+            "expected ':'",
+            (2, 34),
+            (2, 35),
+        ),
     ],
 )
 def test_invalid_with_stmt(
     python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -395,13 +477,21 @@ def test_invalid_with_stmt(
             None,
         ),
         ("try\n\tpass", SyntaxError, "expected ':'", (1, 4), (1, 5)),
-        ("try:\n\tpass\na = 1", SyntaxError, "expected 'except' or 'finally' block", (3, 1), (3, 2)),
+        (
+            "try:\n\tpass\na = 1",
+            SyntaxError,
+            "expected 'except' or 'finally' block",
+            (3, 1),
+            (3, 2),
+        ),
     ],
 )
 def test_invalid_try_stmt(
     python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -457,14 +547,22 @@ def test_invalid_try_stmt(
             (None, None),
         ),
         ("try:\n\tpass\nexcept Exception\npass", SyntaxError, "expected ':'", (3, 17), (3, 18)),
-        ("try:\n\tpass\nexcept Exception as e\npass", SyntaxError, "expected ':'", (3, 22), (3, 23)),
+        (
+            "try:\n\tpass\nexcept Exception as e\npass",
+            SyntaxError,
+            "expected ':'",
+            (3, 22),
+            (3, 23),
+        ),
         ("try:\n\tpass\nexcept\npass", SyntaxError, "expected ':'", (3, 7), (3, 8)),
     ],
 )
 def test_invalid_except_stmt(
     python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -503,10 +601,11 @@ def test_invalid_finally_stmt(
     ],
 )
 def test_invalid_match_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Valid only in Python 3.10+")
@@ -524,10 +623,11 @@ def test_invalid_match_stmt(
     ],
 )
 def test_invalid_case_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Valid only in Python 3.10+")
@@ -535,7 +635,13 @@ def test_invalid_case_stmt(
     "source, exception, message, start, end",
     [
         # As pattern
-        ("match a:\n\tcase 1 as _:\n\t\tpass", SyntaxError, "cannot use '_' as a target", (2, 12), (2, 13)),
+        (
+            "match a:\n\tcase 1 as _:\n\t\tpass",
+            SyntaxError,
+            "cannot use '_' as a target",
+            (2, 12),
+            (2, 13),
+        ),
         (
             "match a:\n\tcase 1 as 1+1:\n\tpass",
             SyntaxError,
@@ -575,10 +681,11 @@ def test_invalid_case_stmt(
     ],
 )
 def test_invalid_case_pattern(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -595,10 +702,11 @@ def test_invalid_case_pattern(
     ],
 )
 def test_invalid_if_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -615,10 +723,11 @@ def test_invalid_if_stmt(
     ],
 )
 def test_invalid_elif_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -635,10 +744,11 @@ def test_invalid_elif_stmt(
     ],
 )
 def test_invalid_else_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -655,10 +765,11 @@ def test_invalid_else_stmt(
     ],
 )
 def test_invalid_while_stmt(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )
 
 
 @pytest.mark.parametrize(
@@ -754,16 +865,47 @@ def test_invalid_class_stmt(
     [
         ("{a: 1, b}", SyntaxError, "':' expected after dictionary key", (1, 7), (1, 9)),
         ("{a: 1, c: 2, b}", SyntaxError, "':' expected after dictionary key", (1, 13), (1, 15)),
-        ("{a: 1, b:}", SyntaxError, "expression expected after dictionary key and ':'", (1, 9), (1, 10)),
-        ("{c: 1, a: *b}", SyntaxError, "cannot use a starred expression in a dictionary value", (1, 11), (1, 14)),
+        (
+            "{a: 1, b:}",
+            SyntaxError,
+            "expression expected after dictionary key and ':'",
+            (1, 9),
+            (1, 10),
+        ),
+        (
+            "{c: 1, a: *b}",
+            SyntaxError,
+            "cannot use a starred expression in a dictionary value",
+            (1, 11),
+            (1, 14),
+        ),
         ("{b:}", SyntaxError, "expression expected after dictionary key and ':'", (1, 3), (1, 4)),
-        ("{b:, c}", SyntaxError, "expression expected after dictionary key and ':'", (1, 3), (1, 4)),
-        ("{a: *b}", SyntaxError, "cannot use a starred expression in a dictionary value", (1, 5), (1, 8)),
-        ("{**c, a: *b}", SyntaxError, "cannot use a starred expression in a dictionary value", (1, 10), (1, 13)),
+        (
+            "{b:, c}",
+            SyntaxError,
+            "expression expected after dictionary key and ':'",
+            (1, 3),
+            (1, 4),
+        ),
+        (
+            "{a: *b}",
+            SyntaxError,
+            "cannot use a starred expression in a dictionary value",
+            (1, 5),
+            (1, 8),
+        ),
+        (
+            "{**c, a: *b}",
+            SyntaxError,
+            "cannot use a starred expression in a dictionary value",
+            (1, 10),
+            (1, 13),
+        ),
     ],
 )
 def test_invalid_dict_key_value(
-    python_parse_file, python_parse_str, tmp_path, source, exception, message,
-    start, end
+    python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
-    parse_invalid_syntax(python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end)
+    parse_invalid_syntax(
+        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+    )

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -34,10 +34,9 @@ def parse_invalid_syntax(
             start[1],
         ), f"expected start location of {start} but got {(exc.lineno, exc.offset)}"
     else:
-        assert exc.lineno is None and exc.offset is None, (
-            f"missing start location ({exc.lineno}, {exc.offset})"
-            + f" xxx ({exc.end_lineno}, {exc.end_offset})"
-        )
+        assert (
+            exc.lineno is None and exc.offset is None
+        ), f"missing start location ({exc.lineno}, {exc.offset})"
 
     if sys.version_info >= (3, 10):
         if end:


### PR DESCRIPTION
As suggested by @MatthieuDartiailh in [this comment](https://github.com/we-like-parsers/pegen/issues/47#issuecomment-933217996), this is a completion of #41 (which includes @MatthieuDartiailh original commits) that includes all the row/column tests, as well as a fix to my issue #47.
