### PR TITLE
Add missing tox test requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     extras_require={
         'docs': ['sphinx', 'sphinx-copybutton', 'furo'],
         'lint': ['black', 'flake8', 'mypy'],
-        'test': ['pytest', 'pytest-cov'],
+        'test': ['pytest', 'pytest-cov', 'tox'],
     },
     project_urls={
         'Bug Reports': 'https://github.com/we-like-parsers/pegen/issues',


### PR DESCRIPTION
`tox` is missing from the test dependencies. This PR adds it.