### PR TITLE
Delayed error inspection

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -112,9 +112,22 @@ class Parser(Parser):
         self.py_version = min(py_version, sys.version_info) if py_version else sys.version_info
         self._exception = None
 
-    def parse(self, rule: str) -> Optional[ast.AST]:
+    def parse(self, rule: str, call_invalid_rules: bool = False) -> Optional[ast.AST]:
+        old = self.call_invalid_rules
+        self.call_invalid_rules = call_invalid_rules
         res = getattr(self, rule)()
+
         if res is None:
+            if not call_invalid_rules:
+                self.call_invalid_rules = True
+
+                # Reset the parser cache to be able to restart parsing from the
+                # beginning.
+                self._reset(0)  # type: ignore
+                self._cache.clear()
+
+                res = getattr(self, rule)()
+
             if self._exception is not None:
                 raise self._exception
             else:

--- a/data/python.gram
+++ b/data/python.gram
@@ -1593,11 +1593,12 @@ invalid_arguments[NoReturn]:
             "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b
         )
      }
-    | a=args for_if_clauses {
-        self.store_syntax_error_starting_from(
+    | a=args b=for_if_clauses {
+        self.store_syntax_error_known_range(
             "Generator expression must be parenthesized",
-            a[1][-1] if a[1] else a[0][-1]
-        )
+            a[0][-1],
+            b[-1].target
+        ) if len(a[0]) > 1 else None
      }
     | args ',' a=expression b=for_if_clauses {
         self.store_syntax_error_known_range(

--- a/data/python.gram
+++ b/data/python.gram
@@ -178,14 +178,14 @@ class Parser(Parser):
 
     def ensure_real(self, number_str: str):
         number = ast.literal_eval(number_str)
-        if number is not complex:
+        if type(number) is complex:
             self.raise_syntax_error("real number required in complex literal")
         return number
 
     def ensure_imaginary(self, number_str: str):
         number = ast.literal_eval(number_str)
-        if number is not complex:
-            self.raise_syntax_error("imaginary  number required in complex literal")
+        if type(number) is not complex:
+            self.raise_syntax_error("imaginary number required in complex literal")
         return number
 
     def generate_ast_for_string(self, tokens):

--- a/data/python.gram
+++ b/data/python.gram
@@ -110,7 +110,6 @@ class Parser(Parser):
         super().__init__(tokenizer, verbose=verbose)
         self.filename = filename
         self.py_version = min(py_version, sys.version_info) if py_version else sys.version_info
-        self._exception = None
 
     def parse(self, rule: str, call_invalid_rules: bool = False) -> Optional[ast.AST]:
         old = self.call_invalid_rules
@@ -118,6 +117,11 @@ class Parser(Parser):
         res = getattr(self, rule)()
 
         if res is None:
+
+            # Grab the last token that was parsed in the first run to avoid
+            # polluting a generic error reports with progress made by invalid rules.
+            last_token = self._tokenizer.diagnose()
+
             if not call_invalid_rules:
                 self.call_invalid_rules = True
 
@@ -128,10 +132,7 @@ class Parser(Parser):
 
                 res = getattr(self, rule)()
 
-            if self._exception is not None:
-                raise self._exception
-            else:
-                raise SyntaxError("invalid syntax")
+            self.raise_syntax_error_starting_from("invalid syntax", last_token)
 
         return res
 
@@ -178,13 +179,13 @@ class Parser(Parser):
     def ensure_real(self, number_str: str):
         number = ast.literal_eval(number_str)
         if number is not complex:
-            self.store_syntax_error("real number required in complex literal")
+            self.raise_syntax_error("real number required in complex literal")
         return number
 
     def ensure_imaginary(self, number_str: str):
         number = ast.literal_eval(number_str)
         if number is not complex:
-            self.store_syntax_error("imaginary  number required in complex literal")
+            self.raise_syntax_error("imaginary  number required in complex literal")
         return number
 
     def generate_ast_for_string(self, tokens):
@@ -219,7 +220,7 @@ class Parser(Parser):
         # Avoid getting a triple nesting in the error report that does not
         # bring anything relevant to the traceback.
         if err_msg:
-            self.store_syntax_error_known_location(err_msg, t)
+            self.raise_syntax_error_known_location(err_msg, t)
             raise self._exception
 
         return m.body[0].value
@@ -296,7 +297,7 @@ class Parser(Parser):
             kwarg=after_star[2]
         )
 
-    def _store_syntax_error(
+    def _build_syntax_error(
         self,
         message: str,
         start: Optional[Tuple[int, int]] = None,
@@ -316,20 +317,28 @@ class Parser(Parser):
                 self._tokenizer.get_lines(list(range(start[0], end[0] + 1)))
             )
 
-        self._exception = SyntaxError(
+        return  SyntaxError(
             message,
             (self.filename, start[0], start[1], line)
         )
 
-    def store_syntax_error(self, message: str) -> None:
-        self._store_syntax_error(message)
+    def raise_raw_syntax_error(
+        self,
+        message: str,
+        start: Optional[Tuple[int, int]] = None,
+        end: Optional[Tuple[int, int]] = None
+    ) -> None:
+        raise self._build_syntax_error(message, start, end)
 
     def make_syntax_error(self, message: str) -> None:
-        self._store_syntax_error(message)
-        return self._exception
+        return self._build_syntax_error(message)
 
-    def store_syntax_error_known_location(self, message: str, node) -> None:
-        """Store a syntax error that occured at a given AST node."""
+    def raise_syntax_error(self, message: str) -> None:
+        """Raise a syntax error."""
+        raise self._build_syntax_error(message)
+
+    def raise_syntax_error_known_location(self, message: str, node) -> None:
+        """Raise a syntax error that occured at a given AST node."""
         if isinstance(node, tokenize.TokenInfo):
             start = node.start
             end = node.end
@@ -337,9 +346,9 @@ class Parser(Parser):
             start = node.lineno, node.col_offset
             end = node.end_lineno, node.end_col_offset
 
-        self._store_syntax_error(message, start, end)
+        raise self._build_syntax_error(message, start, end)
 
-    def store_syntax_error_known_range(
+    def raise_syntax_error_known_range(
         self,
         message: str,
         start_node: Union[ast.AST, tokenize.TokenInfo],
@@ -355,9 +364,9 @@ class Parser(Parser):
         else:
             end = end_node.end_lineno, end_node.end_col_offset
 
-        self._store_syntax_error(message, start, end)
+        raise self._build_syntax_error(message, start, end)
 
-    def store_syntax_error_starting_from(
+    def raise_syntax_error_starting_from(
         self,
         message: str,
         start_node: Union[ast.AST, tokenize.TokenInfo]
@@ -367,37 +376,7 @@ class Parser(Parser):
         else:
             start = start_node.lineno, start_node.col_offset
 
-        self._store_syntax_error(message, start, None)
-
-    def raise_syntax_error(self, message: str) -> NoReturn:
-        self._store_syntax_error(message)
-        raise self._exception
-
-    def raise_syntax_error_known_location(
-            self,
-            message: str,
-            node: Union[ast.AST, tokenize.TokenInfo]
-        ) -> NoReturn:
-        """Raise a syntax error that occured at a given AST node."""
-        self.store_syntax_error_known_location(message, node)
-        raise self._exception
-
-    def raise_syntax_error_known_range(
-        self,
-        message: str,
-        start_node: Union[ast.AST, tokenize.TokenInfo],
-        end_node: Union[ast.AST, tokenize.TokenInfo]
-    ) -> NoReturn:
-        self.store_syntax_error_known_range(message, start_node, end_node)
-        raise self._exception
-
-    def raise_syntax_error_starting_from(
-        self,
-        message: str,
-        start_node: Union[ast.AST, tokenize.TokenInfo]
-    ) -> NoReturn:
-        self.store_syntax_error_starting_from(message, start_node)
-        raise self._exception
+        raise self._build_syntax_error(message, start, None)
 
 '''
 
@@ -1578,37 +1557,37 @@ func_type_comment:
 # From here on, there are rules for invalid syntax with specialised error messages
 invalid_arguments[NoReturn]:
     | a=args ',' '*' {
-        self.store_syntax_error_known_location(
+        self.raise_syntax_error_known_location(
             "iterable argument unpacking follows keyword argument unpacking",
             a[1][-1] if a[1] else a[0][-1],
         )
      }
     | a=expression b=for_if_clauses ',' [args | expression for_if_clauses] {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "Generator expression must be parenthesized", a, b[-1].target
         )
      }
     | a=NAME b='=' expression for_if_clauses {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b
         )
      }
     | a=args b=for_if_clauses {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "Generator expression must be parenthesized",
             a[0][-1],
             b[-1].target
         ) if len(a[0]) > 1 else None
      }
     | args ',' a=expression b=for_if_clauses {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "Generator expression must be parenthesized",
             a,
             b[-1].target,
         )
      }
     | a=args ',' args {
-        self.store_syntax_error(
+        self.raise_syntax_error(
             "positional argument follows keyword argument unpacking"
             if a[1][-1].arg is None else
             "positional argument follows keyword argument",
@@ -1616,12 +1595,12 @@ invalid_arguments[NoReturn]:
      }
 invalid_kwarg[NoReturn]:
     | a=NAME b='=' expression for_if_clauses {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b
         )
      }
     | !(NAME '=') a=expression b='=' {
-        self.store_syntax_error_known_range(
+        self.raise_syntax_error_known_range(
             "expression cannot contain assignment, perhaps you meant \"==\"?", a, b,
         )
      }
@@ -1642,14 +1621,14 @@ invalid_expression[NoReturn]:
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
     | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
-        self.store_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)
+        self.raise_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)
      }
     | a=disjunction 'if' b=disjunction !('else'|':') {
-        self.store_syntax_error_known_range("expected 'else' after 'if' expression", a, b)
+        self.raise_syntax_error_known_range("expected 'else' after 'if' expression", a, b)
      }
 invalid_named_expression[NoReturn]:
     | a=expression ':=' expression {
-        self.store_syntax_error_known_location(
+        self.raise_syntax_error_known_location(
             f"cannot use assignment expressions with {self.get_expr_name(a)}", a
         )
      }
@@ -1658,7 +1637,7 @@ invalid_named_expression[NoReturn]:
         (
             None
             if self.in_recursive_rule else
-            self.store_syntax_error_known_range(
+            self.raise_syntax_error_known_range(
                 "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b
             )
         )
@@ -1667,7 +1646,7 @@ invalid_named_expression[NoReturn]:
         (
             None
             if self.in_recursive_rule else
-            self.store_syntax_error_known_range(
+            self.raise_syntax_error_known_range(
                 f"cannot assign to {self.get_expr_name(a)} here. Maybe you meant '==' instead of '='?", a, b
             )
         )
@@ -1675,22 +1654,22 @@ invalid_named_expression[NoReturn]:
 
 invalid_assignment[NoReturn]:
     | a=invalid_ann_assign_target ':' expression {
-        self.store_syntax_error_known_location(
+        self.raise_syntax_error_known_location(
             f"only single target (not {self.get_expr_name(a)}) can be annotated", a
         )
      }
     | a=star_named_expression ',' star_named_expressions* ':' expression {
-        self.store_syntax_error_known_location("only single target (not tuple) can be annotated", a) }
+        self.raise_syntax_error_known_location("only single target (not tuple) can be annotated", a) }
     | a=expression ':' expression {
-        self.store_syntax_error_known_location("illegal target for annotation", a) }
+        self.raise_syntax_error_known_location("illegal target for annotation", a) }
     | (star_targets '=')* a=star_expressions '=' {
-        self.store_syntax_error_known_location(f"cannot assign to {self.get_expr_name(a)}", a)
+        self.raise_syntax_error_known_location(f"cannot assign to {self.get_expr_name(a)}", a)
      }
     | (star_targets '=')* a=yield_expr '=' {
-        self.store_syntax_error_known_location("assignment to yield expression not possible", a)
+        self.raise_syntax_error_known_location("assignment to yield expression not possible", a)
      }
     | a=star_expressions augassign (yield_expr | star_expressions) {
-        self.store_syntax_error_known_location(
+        self.raise_syntax_error_known_location(
             f"{self.get_expr_name(a)} is an illegal expression for augmented assignment", a
         )
      }
@@ -1738,9 +1717,9 @@ invalid_lambda_parameters_helper[NoReturn]:
     | a=lambda_param_with_default+
 invalid_star_etc[NoReturn]:
     | a='*' (')' | ',' (')' | '**')) {
-        self.store_syntax_error_known_location("named arguments must follow bare *", a)
+        self.raise_syntax_error_known_location("named arguments must follow bare *", a)
      }
-    | '*' ',' TYPE_COMMENT { self.store_syntax_error("bare * has associated type comment") }
+    | '*' ',' TYPE_COMMENT { self.raise_syntax_error("bare * has associated type comment") }
 invalid_lambda_star_etc[NoReturn]:
     | '*' (':' | ',' (':' | '**')) {
         self.raise_syntax_error("named arguments must follow bare *")
@@ -1799,8 +1778,8 @@ invalid_except_stmt[None]:
     | 'except' a=expression ',' expressions ['as' NAME ] ':' {
         self.raise_syntax_error_starting_from("exception group must be parenthesized", a)
      }
-    | a='except' expression ['as' NAME ] NEWLINE { self.store_syntax_error("expected ':'") }
-    | a='except' NEWLINE { self.store_syntax_error("expected ':'") }
+    | a='except' expression ['as' NAME ] NEWLINE { self.raise_syntax_error("expected ':'") }
+    | a='except' NEWLINE { self.raise_syntax_error("expected ':'") }
 invalid_finally_stmt[NoReturn]:
     | a='finally' ':' NEWLINE !INDENT {
         self.raise_indentation_error(
@@ -1836,7 +1815,7 @@ invalid_match_stmt[NoReturn]:
         )
      }
 invalid_case_block[NoReturn]:
-    | "case" patterns guard? !':' { self.store_syntax_error("expected ':'") }
+    | "case" patterns guard? !':' { self.raise_syntax_error("expected ':'") }
     | a="case" patterns guard? ':' NEWLINE !INDENT {
         self.raise_indentation_error(
             f"expected an indented block after 'case' statement on line {a.start[0]}"
@@ -1878,7 +1857,7 @@ invalid_else_stmt[NoReturn]:
         )
      }
 invalid_while_stmt[NoReturn]:
-    | 'while' named_expression NEWLINE { self.store_syntax_error("expected ':'") }
+    | 'while' named_expression NEWLINE { self.raise_syntax_error("expected ':'") }
     | a='while' named_expression ':' NEWLINE !INDENT {
         self.raise_indentation_error(
             f"expected an indented block after 'while' statement on line {a.start[0]}"
@@ -1906,22 +1885,22 @@ invalid_class_def_raw[NoReturn]:
 invalid_double_starred_kvpairs[None]:
     | ','.double_starred_kvpair+ ',' invalid_kvpair
     | expression ':' a='*' bitwise_or {
-        self.store_syntax_error_starting_from("cannot use a starred expression in a dictionary value", a)
+        self.raise_syntax_error_starting_from("cannot use a starred expression in a dictionary value", a)
      }
     | expression a=':' &('}'|',') {
-        self.store_syntax_error_known_location("expression expected after dictionary key and ':'", a)
+        self.raise_syntax_error_known_location("expression expected after dictionary key and ':'", a)
      }
 invalid_kvpair[None]:
     | a=expression !(':') {
-        self._store_syntax_error(
+        self.raise_raw_syntax_error(
             "':' expected after dictionary key",
             (a.lineno, a.col_offset - 1),
             (a.end_lineno, a.end_col_offset, -1)
         )
      }
     | expression ':' a='*' bitwise_or {
-        self.store_syntax_error_starting_from("cannot use a starred expression in a dictionary value", a)
+        self.raise_syntax_error_starting_from("cannot use a starred expression in a dictionary value", a)
      }
     | expression a=':' {
-        self.store_syntax_error_known_location("expression expected after dictionary key and ':'", a)
+        self.raise_syntax_error_known_location("expression expected after dictionary key and ':'", a)
      }

--- a/docs/grammar.rst
+++ b/docs/grammar.rst
@@ -158,7 +158,7 @@ parsed.
 ``&&e``
 '''''''
 
-Fail immediatly if e fails to parse by raising the exception built using
+Fail immediately if e fails to parse by raising the exception built using
 the ``make_syntax_error`` method.
 
 This construct can help provide better error messages.
@@ -311,20 +311,26 @@ and “hidden left-recursion” like::
 Syntax error related rules
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Rules meant to provide better error reporting on syntax error are useful
-but can be tricky:
+Rules starting with ``invalid`` are meant to provide better error reporting on
+syntax error. They are ignored by the parser unless the ``call_invalid_rules``
+attribute of the parser is set to ``True``. This allows for faster parsing on
+the happy path and nicer errors can be generated in a second path as is done
+in the Python parser.
 
--  they will prevent the parser from back tracking which may not always
-   be desirable. In those cases one can customize the parser to delay
-   the error reporting.
--  secondly when used in the alternative of another rule, this
-   alternative will never evaluate its action. This can be annoying to
-   measure the code coverage on the parser. To alleviate this issue, all
-   rule alternatives making use of a rule whose name starts with
-   ``'invalid'`` will have its action set to ``UNREACHABLE`` if no
-   action was specified. ``UNREACHABLE`` is a special action which will
-   be replaced by the value of the ``unreachable_formatting`` which
-   defaults to ``None  # pragma: no cover``.
+.. note::
+
+   Rule whose name ends in ``without_invalid`` will never call ``invalid``
+   rules which avoids possibly infinite recursion.
+
+.. note::
+
+   When used in the alternative of another rule, this alternative will never
+   evaluate its action. This can be annoying to measure the code coverage on
+   the parser. To alleviate this issue, all rule alternatives making use of a
+   rule whose name starts with ``'invalid'`` will have its action set to
+   ``UNREACHABLE`` if no action was specified. ``UNREACHABLE`` is a special
+   action which will be replaced by the value of the ``unreachable_formatting``
+   which defaults to ``None  # pragma: no cover``.
 
 .. note::
     Rules making use of the ``&&`` forced operator to generate syntax error

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -168,16 +168,17 @@ class Parser:
         self._verbose = verbose
         self._level = 0
         self._cache: Dict[Tuple[Mark, str, Tuple[Any, ...]], Tuple[Any, Mark]] = {}
+
         # Integer tracking wether we are in a left recursive rule or not. Can be useful
         # for error reporting.
         self.in_recursive_rule = 0
+
         # Pass through common tokenizer methods.
         self._mark = self._tokenizer.mark
         self._reset = self._tokenizer.reset
 
-    @abstractmethod
-    def start(self) -> Any:
-        pass
+        # Are we looking for syntax error ? When true enable matching on invalid rules
+        self.call_invalid_rules = False
 
     def showpeek(self) -> str:
         tok = self._tokenizer.peek()

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -452,31 +452,41 @@ def test_invalid_case_stmt(
         # As pattern
         ("match a:\n\tcase 1 as _:\n\t\tpass", SyntaxError, "cannot use '_' as a target"),
         (
-            "match a:\n\tcase 1 as 1+1:\n\tpass",
+            "match a:\n\tcase 1 as 1+1:\n\t\tpass",
             SyntaxError,
             "invalid pattern target",
         ),
         # Class pattern
         (
-            "match a:\n\tcase Foo(z=1, y=2, x):\n\tpass",
+            "match a:\n\tcase Foo(z=1, y=2, x):\n\t\tpass",
             SyntaxError,
             "positional patterns follow keyword patterns",
         ),
         (
-            "match a:\n\tcase Foo(a, z=1, y=2, x):\n\tpass",
+            "match a:\n\tcase Foo(a, z=1, y=2, x):\n\t\tpass",
             SyntaxError,
             "positional patterns follow keyword patterns",
         ),
         (
-            "match a:\n\tcase Foo(z=1, x, y=2):\n\tpass",
+            "match a:\n\tcase Foo(z=1, x, y=2):\n\t\tpass",
             SyntaxError,
             "positional patterns follow keyword patterns",
         ),
         (
-            "match a:\n\tcase Foo(a=b, c, d=e, f, g=h, i, j=k, ...):\n\tpass",
+            "match a:\n\tcase Foo(a=b, c, d=e, f, g=h, i, j=k, ...):\n\t\tpass",
             SyntaxError,
             "positional patterns follow keyword patterns",
         ),
+        (
+            "match x:\n\tcase -1j + 1j:\n\t\tpass",
+            SyntaxError,
+            "real number required in complex literal",
+        ),
+        (
+            "match x:\n\tcase -1 + 1:\n\t\tpass",
+            SyntaxError,
+            "imaginary number required in complex literal",
+        )
     ],
 )
 def test_invalid_case_pattern(

--- a/tests/python_parser/test_unsupported_syntax.py
+++ b/tests/python_parser/test_unsupported_syntax.py
@@ -31,7 +31,7 @@ def test_await(python_parser_cls):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 4))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Await expressions are" in e.exconly()
 
@@ -51,7 +51,7 @@ def test_async(python_parser_cls, source, message):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 4))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert message in e.exconly()
 
@@ -63,7 +63,7 @@ def test_async_comprehension(python_parser_cls):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 5))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
     assert "Async comprehensions are" in e.exconly()
 
 
@@ -75,7 +75,7 @@ def test_variable_annotation(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 5))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Variable annotation syntax is" in e.exconly()
 
@@ -88,7 +88,7 @@ def test_pos_only_args(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 7))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Positional only arguments are" in e.exconly()
 
@@ -101,7 +101,7 @@ def test_assignment_operator(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 7))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "The ':=' operator is" in e.exconly()
 
@@ -114,7 +114,7 @@ def test_generic_decorators(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 8))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Generic decorator are" in e.exconly()
 
@@ -127,7 +127,7 @@ def test_parenthesized_with_items(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 8))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Parenthesized with items" in e.exconly()
 
@@ -142,6 +142,6 @@ def test_match_statement(python_parser_cls, source):
     tokenizer = Tokenizer(tokengen, verbose=False)
     pp = python_parser_cls(tokenizer, py_version=(3, 9))
     with pytest.raises(SyntaxError) as e:
-        pp.file()
+        pp.parse("file")
 
     assert "Pattern matching is" in e.exconly()


### PR DESCRIPTION
This attempts to mimic CPython behavior by calling invalid rule only in a second pass to speed up parsing on the happy path. It also includes changes https://github.com/python/cpython/commit/390459de6db1e68b79c0897cc88c0d562693ec5c to avoid calling invalid rules from within without invalid rules.

~~With those changes, I thought I would be able to get rid of having both immediate and deferred raising of exceptions (store_ vs raise_) since looking at CPython it looks to me as if as soon as an exception is reported the parser exits. This fast exit is controlled by the error_indicator attribute on the parser state. However I hit one issue when enabling direct raising in invalid rules (so in CPython terms when looking for details about a syntax error):
`f(i for i in range(10))` fails to parse because in t_primary the alternative a=t_primary b=genexp &t_lookahead fails and then the alternative a=t_primary '(' b=[arguments] ')' &t_lookahead trips through the invalid argument rule. This should parse and would mask any actual error.~~

~~I would very much appreciate if somebody could shed some light on this issue.~~

This will need some extra documentation and tests once the above has been addressed.
