### PR TITLE
Improved syntax error

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -698,7 +698,7 @@ function_def[Union[ast.FunctionDef, ast.AsyncFunctionDef]]:
 
 function_def_raw[Union[ast.FunctionDef, ast.AsyncFunctionDef]]:
     | invalid_def_raw
-    | 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
+    | 'def' n=NAME &&'(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
         ast.FunctionDef(
             name=n.string,
             args=params or self.make_arguments(None, [], None, [], None),
@@ -708,7 +708,7 @@ function_def_raw[Union[ast.FunctionDef, ast.AsyncFunctionDef]]:
             LOCATIONS,
         )
      }
-    | 'async' 'def' n=NAME '(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
+    | 'async' 'def' n=NAME &&'(' params=[params] ')' a=['->' z=expression { z }] &&':' tc=[func_type_comment] b=block {
        self.check_version(
             (3, 5),
             "Async functions are",

--- a/data/python.gram
+++ b/data/python.gram
@@ -1795,12 +1795,18 @@ invalid_parameters[NoReturn]:
     | param_no_default* invalid_parameters_helper a=param_no_default {
         self.raise_syntax_error_known_location("non-default argument follows default argument", a)
      }
+    | param_no_default* a='(' param_no_default+ ','? b=')' {
+        self.raise_syntax_error_known_range("Function parameters cannot be parenthesized", a, b)
+     }
 invalid_parameters_helper: # This is only there to avoid type errors
     | a=slash_with_default { [a] }
     | a=param_with_default+
 invalid_lambda_parameters[NoReturn]:
     | lambda_param_no_default* invalid_lambda_parameters_helper a=lambda_param_no_default {
         self.raise_syntax_error_known_location("non-default argument follows default argument", a)
+     }
+    | lambda_param_no_default* a='(' ','.lambda_param+ ','? b=')' {
+        self.raise_syntax_error_known_range("Lambda expression parameters cannot be parenthesized", a, b)
      }
 invalid_lambda_parameters_helper[NoReturn]:
     | a=lambda_slash_with_default { [a] }

--- a/data/python.gram
+++ b/data/python.gram
@@ -763,12 +763,14 @@ slash_with_default[List[Tuple[ast.arg, Any]]]:
     | a=param_no_default* b=param_with_default+ '/' &')' { ([(p, None) for p in a] if a else []) + b }
 
 star_etc[Tuple[Optional[ast.arg], List[Tuple[ast.arg, Any]], Optional[ast.arg]]]:
+    | invalid_star_etc
     | '*' a=param_no_default b=param_maybe_default* c=[kwds] { (a, b, c) }
     | '*' ',' b=param_maybe_default+ c=[kwds] { (None, b, c) }
     | a=kwds { (None, [], a) }
-    | invalid_star_etc
 
-kwds: '**' a=param_no_default { a }
+kwds[ast.arg]:
+    | invalid_kwds
+    | '**' a=param_no_default { a }
 
 # One parameter.  This *includes* a following comma and type comment.
 #
@@ -794,7 +796,7 @@ param_maybe_default[Tuple[ast.arg, Any]]:
     | a=param c=default? tc=TYPE_COMMENT? &')' { (self.set_arg_type_comment(a, tc), c) }
 param: a=NAME b=annotation? { ast.arg(arg=a.string, annotation=b, LOCATIONS) }
 annotation: ':' a=expression { a }
-default: '=' a=expression { a }
+default: '=' a=expression { a } | invalid_default
 
 # If statement
 # ------------
@@ -1407,14 +1409,16 @@ lambda_slash_with_default[List[Tuple[ast.arg, Any]]]:
     | a=lambda_param_no_default* b=lambda_param_with_default+ '/' &':' { ([(p, None) for p in a] if a else []) + b }
 
 lambda_star_etc[Tuple[Optional[ast.arg], List[Tuple[ast.arg, Any]], Optional[ast.arg]]]:
+    | invalid_lambda_star_etc
     | '*' a=lambda_param_no_default b=lambda_param_maybe_default* c=[lambda_kwds] {
        (a, b, c) }
     | '*' ',' b=lambda_param_maybe_default+ c=[lambda_kwds] {
         (None, b, c) }
     | a=lambda_kwds { (None, [], a) }
-    | invalid_lambda_star_etc
 
-lambda_kwds[ast.arg]: '**' a=lambda_param_no_default { a }
+lambda_kwds[ast.arg]:
+    | invalid_lambda_kwds
+    | '**' a=lambda_param_no_default { a }
 
 lambda_param_no_default[ast.arg]:
     | a=lambda_param ',' { a }
@@ -1798,6 +1802,43 @@ invalid_parameters[NoReturn]:
     | param_no_default* a='(' param_no_default+ ','? b=')' {
         self.raise_syntax_error_known_range("Function parameters cannot be parenthesized", a, b)
      }
+    | a="/" ',' {
+        self.raise_syntax_error_known_location("at least one argument must precede /", a)
+     }
+    | (slash_no_default | slash_with_default) param_maybe_default* a='/' {
+        self.raise_syntax_error_known_location("/ may appear only once", a)
+     }
+    | (slash_no_default | slash_with_default)? param_maybe_default* '*' (',' | param_no_default) param_maybe_default* a='/' {
+        self.raise_syntax_error_known_location("/ must be ahead of *", a)
+     }
+    | param_maybe_default+ '/' a='*' {
+        self.raise_syntax_error_known_location("expected comma between / and *", a)
+     }
+invalid_default:
+    | a='=' &(')'|',') {
+        self.raise_syntax_error_known_location("expected default value expression", a)
+     }
+invalid_star_etc:
+    | a='*' (')' | ',' (')' | '**')) {
+        self.raise_syntax_error_known_location("named arguments must follow bare *", a)
+     }
+    | '*' ',' TYPE_COMMENT { self.raise_syntax_error("bare * has associated type comment") }
+    | '*' param a='=' {
+        self.raise_syntax_error_known_location("var-positional argument cannot have default value", a)
+     }
+    | '*' (param_no_default | ',') param_maybe_default* a='*' (param_no_default | ',') {
+        self.raise_syntax_error_known_location("* argument may appear only once", a)
+     }
+invalid_kwds:
+    | '**' param a='=' {
+        self.raise_syntax_error_known_location("var-keyword argument cannot have default value", a)
+     }
+    | '**' param ',' a=param {
+        self.raise_syntax_error_known_location("arguments cannot follow var-keyword argument", a)
+     }
+    | '**' param ',' a=('*'|'**'|'/') {
+        self.raise_syntax_error_known_location("arguments cannot follow var-keyword argument", a)
+     }
 invalid_parameters_helper: # This is only there to avoid type errors
     | a=slash_with_default { [a] }
     | a=param_with_default+
@@ -1808,17 +1849,40 @@ invalid_lambda_parameters[NoReturn]:
     | lambda_param_no_default* a='(' ','.lambda_param+ ','? b=')' {
         self.raise_syntax_error_known_range("Lambda expression parameters cannot be parenthesized", a, b)
      }
+    | a="/" ',' {
+        self.raise_syntax_error_known_location("at least one argument must precede /", a)
+     }
+    | (lambda_slash_no_default | lambda_slash_with_default) lambda_param_maybe_default* a='/' {
+        self.raise_syntax_error_known_location("/ may appear only once", a)
+     }
+    | (lambda_slash_no_default | lambda_slash_with_default)? lambda_param_maybe_default* '*' (',' | lambda_param_no_default) lambda_param_maybe_default* a='/' {
+        self.raise_syntax_error_known_location("/ must be ahead of *", a)
+     }
+    | lambda_param_maybe_default+ '/' a='*' {
+        self.raise_syntax_error_known_location("expected comma between / and *", a)
+     }
 invalid_lambda_parameters_helper[NoReturn]:
     | a=lambda_slash_with_default { [a] }
     | a=lambda_param_with_default+
-invalid_star_etc[NoReturn]:
-    | a='*' (')' | ',' (')' | '**')) {
-        self.raise_syntax_error_known_location("named arguments must follow bare *", a)
-     }
-    | '*' ',' TYPE_COMMENT { self.raise_syntax_error("bare * has associated type comment") }
 invalid_lambda_star_etc[NoReturn]:
     | '*' (':' | ',' (':' | '**')) {
         self.raise_syntax_error("named arguments must follow bare *")
+     }
+    | '*' lambda_param a='=' {
+        self.raise_syntax_error_known_location("var-positional argument cannot have default value", a)
+     }
+    | '*' (lambda_param_no_default | ',') lambda_param_maybe_default* a='*' (lambda_param_no_default | ',') {
+        self.raise_syntax_error_known_location("* argument may appear only once", a)
+     }
+invalid_lambda_kwds:
+    | '**' lambda_param a='=' {
+        self.raise_syntax_error_known_location("var-keyword argument cannot have default value", a)
+     }
+    | '**' lambda_param ',' a=lambda_param {
+        self.raise_syntax_error_known_location("arguments cannot follow var-keyword argument", a)
+     }
+    | '**' lambda_param ',' a=('*'|'**'|'/') {
+        self.raise_syntax_error_known_location("arguments cannot follow var-keyword argument", a)
      }
 invalid_double_type_comments[NoReturn]:
     | TYPE_COMMENT NEWLINE TYPE_COMMENT NEWLINE INDENT {

--- a/data/python.gram
+++ b/data/python.gram
@@ -1135,6 +1135,7 @@ expressions:
 
 expression (memo):
     | invalid_expression
+    | invalid_legacy_expression
     | a=disjunction 'if' b=disjunction 'else' c=expression {
         ast.IfExp(body=a, test=b, orelse=c, LOCATIONS)
      }
@@ -1711,11 +1712,14 @@ invalid_legacy_expression:
         None
      }
 invalid_expression[NoReturn]:
-    | invalid_legacy_expression
     # !(NAME STRING) is not matched so we don't show this error with some invalid string prefixes like: kf"dsfsdf"
     # Soft keywords need to also be ignored because they can be parsed as NAME NAME
     | !(NAME STRING | SOFT_KEYWORD) a=disjunction b=expression_without_invalid {
-        self.raise_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)
+        (
+            self.raise_syntax_error_known_range("invalid syntax. Perhaps you forgot a comma?", a, b)
+            if not isinstance(a, ast.Name) or a.id not in ("print", "exec")
+            else None
+        )
      }
     | a=disjunction 'if' b=disjunction !('else'|':') {
         self.raise_syntax_error_known_range("expected 'else' after 'if' expression", a, b)

--- a/data/python.gram
+++ b/data/python.gram
@@ -1681,6 +1681,9 @@ invalid_arguments[NoReturn]:
         )
      }
 invalid_kwarg[NoReturn]:
+    | a=('True'|'False'|'None') b='=' {
+        self.raise_syntax_error_known_range(f"cannot assign to {a.string}", a, b)
+     }
     | a=NAME b='=' expression for_if_clauses {
         self.raise_syntax_error_known_range(
             "invalid syntax. Maybe you meant '==' or ':=' instead of '='?", a, b

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -352,24 +352,107 @@ def test_invalid_comprehension(
 
 
 @pytest.mark.parametrize(
-    "source, start, end",
+    "source, message, start, end, py_version",
     [
-        ("def f(a=1, b):\n\tpass", (1, 12), (1, 13)),
-        ("def f(a=1, /, b):\n\tpass", (1, 15), (1, 16)),
-        ("lambda x=1, y: x", (1, 13), (1, 14)),
-        ("lambda x=1, /, y: x", (1, 16), (1, 17)),
+        (
+            "def f(a=1, b):\n\tpass",
+            "non-default argument follows default argument",
+            (1, 12),
+            (1, 13),
+            (3, 10),
+        ),
+        (
+            "def f(a=1, /, b):\n\tpass",
+            "non-default argument follows default argument",
+            (1, 15),
+            (1, 16),
+            (3, 10),
+        ),
+        (
+            "def f(x, (y, z), w):\n\tpass",
+            "parameters cannot be parenthesized",
+            (1, 10),
+            (1, 16),
+            (3, 11),
+        ),
+        (
+            "def f((x, y, z, w)):\n\tpass",
+            "parameters cannot be parenthesized",
+            (1, 7),
+            (1, 19),
+            (3, 11),
+        ),
+        (
+            "def f(x, (y, z, w)):\n\tpass",
+            "parameters cannot be parenthesized",
+            (1, 10),
+            (1, 19),
+            (3, 11),
+        ),
+        (
+            "def f((x, y, z), w):\n\tpass",
+            "parameters cannot be parenthesized",
+            (1, 7),
+            (1, 16),
+            (3, 11),
+        ),
+        (
+            "lambda x=1, y: x",
+            "non-default argument follows default argument",
+            (1, 13),
+            (1, 14),
+            (3, 10),
+        ),
+        (
+            "lambda x=1, /, y: x",
+            "non-default argument follows default argument",
+            (1, 16),
+            (1, 17),
+            (3, 10),
+        ),
+        (
+            "lambda x, (y, z), w: None",
+            "parameters cannot be parenthesized",
+            (1, 11),
+            (1, 17),
+            (3, 11),
+        ),
+        (
+            "lambda (x, y, z, w): None",
+            "parameters cannot be parenthesized",
+            (1, 8),
+            (1, 20),
+            (3, 11),
+        ),
+        (
+            "lambda x, (y, z, w): None",
+            "parameters cannot be parenthesized",
+            (1, 11),
+            (1, 20),
+            (3, 11),
+        ),
+        (
+            "lambda (x, y, z), w: None",
+            "parameters cannot be parenthesized",
+            (1, 8),
+            (1, 17),
+            (3, 11),
+        ),
     ],
 )
-def test_invalid_parameters(python_parse_file, python_parse_str, tmp_path, source, start, end):
+def test_invalid_parameters(
+    python_parse_file, python_parse_str, tmp_path, source, message, start, end, py_version
+):
     parse_invalid_syntax(
         python_parse_file,
         python_parse_str,
         tmp_path,
         source,
         SyntaxError,
-        "non-default argument follows default argument",
+        message,
         start,
         end,
+        py_version,
     )
 
 

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -108,6 +108,7 @@ def test_syntax_error_in_str(
         ("2 if 4", "expected 'else' after 'if' expression", (1, 1), (1, 7)),
         ("(a 1 if b else 2)", "invalid syntax. Perhaps you forgot a comma?", (1, 2), (1, 17)),
         ("(a lambda: 1)", "invalid syntax. Perhaps you forgot a comma?", (1, 2), (1, 13)),
+        ("(a b)", "invalid syntax. Perhaps you forgot a comma?", (1, 2), (1, 5)),
         ("print 1", "Missing parentheses in call to 'print'", (1, 1), (1, 8)),
         ("exec 1", "Missing parentheses in call to 'exec'", (1, 1), (1, 7)),
         ("a if b", "expected 'else' after 'if' expression", (1, 1), (1, 7)),

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -905,6 +905,8 @@ def test_invalid_for_stmt(
             (2, 1),
             (2, 5),
         ),
+        ("def f:", SyntaxError, "expected '('", (1, 6), (1, 6)),
+        ("async def f:", SyntaxError, "expected '('", (1, 12), (1, 12)),
         # (
         #     "def f():\n# type: () -> int\n# type: () -> str\n\tpass",
         #     SyntaxError,
@@ -916,7 +918,15 @@ def test_invalid_def_stmt(
     python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
 ):
     parse_invalid_syntax(
-        python_parse_file, python_parse_str, tmp_path, source, exception, message, start, end
+        python_parse_file,
+        python_parse_str,
+        tmp_path,
+        source,
+        exception,
+        message,
+        start,
+        end,
+        (3, 11) if exception is SyntaxError else (3, 10),
     )
 
 


### PR DESCRIPTION
This is based on #41 but add the changes from:
- bpo45716
- bpo45764
- bpo45727 (except for the fact it triggers only inside parenthesis for Python 3.11)
- bpo45450
- bpo46836

With this pegen will be up to date on syntax error reporting with 3.11
After the 3.11 beta freeze we can add support for `except *` and PEP 646 and we will be up to date with 3.11 grammar