### PR TITLE
Cis: use newer actions (setup-python, checkout, cache)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install pypa/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         git fetch --prune --unshallow
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         python-version: ['3.8','3.9','3.10']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get history and tags for SCM versioning to work
       run: |
         git fetch --prune --unshallow
@@ -25,7 +25,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/tests/python_parser/test_syntax_error_handling.py
+++ b/tests/python_parser/test_syntax_error_handling.py
@@ -44,17 +44,14 @@ def parse_invalid_syntax(
 
     # Check Python message but do not expect message to match for earlier Python versions
     if sys.version_info >= min_python_version:
-        # NOTE ugly hack for 1 CPython bug
-        if exc_cls is SyntaxError and e.type is IndentationError:
-            assert message.replace("'", "") in py_exc.args[0]
-        else:
-            assert message in py_exc.args[0]
+        # This fails for Python < 3.10.5 but keeping the fix for a patch version is not
+        # worth it
+        assert message in py_exc.args[0]
 
     print(str(e.exconly()))
     assert message in str(e.exconly())
 
     # Check start/end line/column on Python 3.10
-
     for parser, exc in ([("Python", py_exc)] if sys.version_info >= min_python_version else []) + [
         ("pegen", e.value)
     ]:


### PR DESCRIPTION
And fix the one broken test on 3.10.5. Setuptools-scm complains but appear to work so I won't touch the fetch.