### PR TITLE
Fix empty last line returned by tokenizer

### DIFF
--- a/releasenotes.rst
+++ b/releasenotes.rst
@@ -11,6 +11,7 @@ unreleased: Version 0.2.0
 - add documentation PR #43 #52
 - sort KEYWORDS to make output deterministic PR #44
 - update grammar_grapher with the new forced (&&) directive PR #57
+- fixed bug where tokenizer reported the last line of source as empty #77
 
 09/06/2021: Version 0.1.0
 -------------------------

--- a/src/pegen/tokenizer.py
+++ b/src/pegen/tokenizer.py
@@ -55,7 +55,7 @@ class Tokenizer:
             ):
                 continue
             self._tokens.append(tok)
-            if not self._path:
+            if not self._path and tok.start[0] not in self._lines:
                 self._lines[tok.start[0]] = tok.line
         return self._tokens[self._index]
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,5 +1,5 @@
 import io
-from tokenize import NEWLINE, NUMBER, TokenInfo, generate_tokens
+from tokenize import NEWLINE, NUMBER, ENDMARKER, TokenInfo, generate_tokens
 
 from pegen.tokenizer import Tokenizer
 
@@ -31,3 +31,12 @@ def test_last_non_whitespace():
     assert t.getnext() == TokenInfo(NUMBER, "1", (2, 0), (2, 1), "1\n")
     assert t.getnext() == TokenInfo(NEWLINE, "\n", (2, 1), (2, 2), "1\n")
     assert t.get_last_non_whitespace_token() == TokenInfo(NUMBER, "1", (2, 0), (2, 1), "1\n")
+
+
+def test_get_lines():
+    source = io.StringIO("1\n2\n3")
+    t = Tokenizer(generate_tokens(source.readline))
+    while True:
+        if t.getnext().type == ENDMARKER:
+            break
+    assert t.get_lines([1, 2, 3]) == ["1\n", "2\n", "3"]


### PR DESCRIPTION
Fixes #76 

This PR fixes an issue where `tokenizer` returns the empty string for the last line if no NEWLINE exists at the end of the source.

Python's `tokenize` module injects a NEWLINE if the source does not end with one. The injected token has the empty string for its `line` but Pegen's tokenizer remembers that empty string as the content of the last line of the source.

Since source does not change over tokenization, once `self._lines[i]` is set for some `i`, it does not need to be set again with later tokens. I added a check to only update `self._lines` only if `tok.start[0]` is not set. With this change, `NEWLINE` injected by the `tokenize` module will not override `self._lines` with the empty string.

I also added a test case for this change.