### PR TITLE
Support Python 3.12 f-strings in grammar actions

### DIFF
--- a/data/Tokens
+++ b/data/Tokens
@@ -59,6 +59,9 @@ AWAIT
 ASYNC
 TYPE_IGNORE
 TYPE_COMMENT
+FSTRING_START
+FSTRING_MIDDLE
+FSTRING_END
 ERRORTOKEN
 
 # These aren't used by the C tokenizer but are needed for tokenize.py

--- a/src/pegen/grammar_parser.py
+++ b/src/pegen/grammar_parser.py
@@ -38,78 +38,112 @@ from pegen.grammar import (
     StringLeaf,
 )
 
-
 # Keywords and soft keywords are listed at the end of the parser definition.
 class GeneratedParser(Parser):
+
     @memoize
     def start(self) -> Optional[Grammar]:
         # start: grammar $
         mark = self._mark()
-        if (grammar := self.grammar()) and (self.expect("ENDMARKER")):
-            return grammar
+        if (
+            (grammar := self.grammar())
+            and
+            (self.expect('ENDMARKER'))
+        ):
+            return grammar;
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def grammar(self) -> Optional[Grammar]:
         # grammar: metas rules | rules
         mark = self._mark()
-        if (metas := self.metas()) and (rules := self.rules()):
-            return Grammar(rules, metas)
+        if (
+            (metas := self.metas())
+            and
+            (rules := self.rules())
+        ):
+            return Grammar ( rules , metas );
         self._reset(mark)
-        if rules := self.rules():
-            return Grammar(rules, [])
+        if (
+            (rules := self.rules())
+        ):
+            return Grammar ( rules , [] );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def metas(self) -> Optional[MetaList]:
         # metas: meta metas | meta
         mark = self._mark()
-        if (meta := self.meta()) and (metas := self.metas()):
-            return [meta] + metas
+        if (
+            (meta := self.meta())
+            and
+            (metas := self.metas())
+        ):
+            return [meta] + metas;
         self._reset(mark)
-        if meta := self.meta():
-            return [meta]
+        if (
+            (meta := self.meta())
+        ):
+            return [meta];
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def meta(self) -> Optional[MetaTuple]:
         # meta: "@" NAME NEWLINE | "@" NAME NAME NEWLINE | "@" NAME STRING NEWLINE
         mark = self._mark()
-        if (self.expect("@")) and (name := self.name()) and (self.expect("NEWLINE")):
-            return (name.string, None)
+        if (
+            (self.expect("@"))
+            and
+            (name := self.name())
+            and
+            (self.expect('NEWLINE'))
+        ):
+            return ( name . string , None );
         self._reset(mark)
         if (
             (self.expect("@"))
-            and (a := self.name())
-            and (b := self.name())
-            and (self.expect("NEWLINE"))
+            and
+            (a := self.name())
+            and
+            (b := self.name())
+            and
+            (self.expect('NEWLINE'))
         ):
-            return (a.string, b.string)
+            return ( a . string , b . string );
         self._reset(mark)
         if (
             (self.expect("@"))
-            and (name := self.name())
-            and (string := self.string())
-            and (self.expect("NEWLINE"))
+            and
+            (name := self.name())
+            and
+            (string := self.string())
+            and
+            (self.expect('NEWLINE'))
         ):
-            return (name.string, literal_eval(string.string))
+            return ( name . string , literal_eval ( string . string ) );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def rules(self) -> Optional[RuleList]:
         # rules: rule rules | rule
         mark = self._mark()
-        if (rule := self.rule()) and (rules := self.rules()):
-            return [rule] + rules
+        if (
+            (rule := self.rule())
+            and
+            (rules := self.rules())
+        ):
+            return [rule] + rules;
         self._reset(mark)
-        if rule := self.rule():
-            return [rule]
+        if (
+            (rule := self.rule())
+        ):
+            return [rule];
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def rule(self) -> Optional[Rule]:
@@ -117,70 +151,107 @@ class GeneratedParser(Parser):
         mark = self._mark()
         if (
             (rulename := self.rulename())
-            and (opt := self.memoflag(),)
-            and (self.expect(":"))
-            and (alts := self.alts())
-            and (self.expect("NEWLINE"))
-            and (self.expect("INDENT"))
-            and (more_alts := self.more_alts())
-            and (self.expect("DEDENT"))
+            and
+            (opt := self.memoflag(),)
+            and
+            (self.expect(":"))
+            and
+            (alts := self.alts())
+            and
+            (self.expect('NEWLINE'))
+            and
+            (self.expect('INDENT'))
+            and
+            (more_alts := self.more_alts())
+            and
+            (self.expect('DEDENT'))
         ):
-            return Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), memo=opt)
+            return Rule ( rulename [0] , rulename [1] , Rhs ( alts . alts + more_alts . alts ) , memo = opt );
         self._reset(mark)
         if (
             (rulename := self.rulename())
-            and (opt := self.memoflag(),)
-            and (self.expect(":"))
-            and (self.expect("NEWLINE"))
-            and (self.expect("INDENT"))
-            and (more_alts := self.more_alts())
-            and (self.expect("DEDENT"))
+            and
+            (opt := self.memoflag(),)
+            and
+            (self.expect(":"))
+            and
+            (self.expect('NEWLINE'))
+            and
+            (self.expect('INDENT'))
+            and
+            (more_alts := self.more_alts())
+            and
+            (self.expect('DEDENT'))
         ):
-            return Rule(rulename[0], rulename[1], more_alts, memo=opt)
+            return Rule ( rulename [0] , rulename [1] , more_alts , memo = opt );
         self._reset(mark)
         if (
             (rulename := self.rulename())
-            and (opt := self.memoflag(),)
-            and (self.expect(":"))
-            and (alts := self.alts())
-            and (self.expect("NEWLINE"))
+            and
+            (opt := self.memoflag(),)
+            and
+            (self.expect(":"))
+            and
+            (alts := self.alts())
+            and
+            (self.expect('NEWLINE'))
         ):
-            return Rule(rulename[0], rulename[1], alts, memo=opt)
+            return Rule ( rulename [0] , rulename [1] , alts , memo = opt );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def rulename(self) -> Optional[RuleName]:
         # rulename: NAME annotation | NAME
         mark = self._mark()
-        if (name := self.name()) and (annotation := self.annotation()):
-            return (name.string, annotation)
+        if (
+            (name := self.name())
+            and
+            (annotation := self.annotation())
+        ):
+            return ( name . string , annotation );
         self._reset(mark)
-        if name := self.name():
-            return (name.string, None)
+        if (
+            (name := self.name())
+        ):
+            return ( name . string , None );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def memoflag(self) -> Optional[str]:
         # memoflag: '(' "memo" ')'
         mark = self._mark()
-        if (self.expect("(")) and (self.expect("memo")) and (self.expect(")")):
-            return "memo"
+        if (
+            (self.expect('('))
+            and
+            (self.expect("memo"))
+            and
+            (self.expect(')'))
+        ):
+            return "memo";
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def alts(self) -> Optional[Rhs]:
         # alts: alt "|" alts | alt
         mark = self._mark()
-        if (alt := self.alt()) and (self.expect("|")) and (alts := self.alts()):
-            return Rhs([alt] + alts.alts)
+        if (
+            (alt := self.alt())
+            and
+            (self.expect("|"))
+            and
+            (alts := self.alts())
+        ):
+            return Rhs ( [alt] + alts . alts );
         self._reset(mark)
-        if alt := self.alt():
-            return Rhs([alt])
+        if (
+            (alt := self.alt())
+        ):
+            return Rhs ( [alt] );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def more_alts(self) -> Optional[Rhs]:
@@ -188,46 +259,77 @@ class GeneratedParser(Parser):
         mark = self._mark()
         if (
             (self.expect("|"))
-            and (alts := self.alts())
-            and (self.expect("NEWLINE"))
-            and (more_alts := self.more_alts())
+            and
+            (alts := self.alts())
+            and
+            (self.expect('NEWLINE'))
+            and
+            (more_alts := self.more_alts())
         ):
-            return Rhs(alts.alts + more_alts.alts)
+            return Rhs ( alts . alts + more_alts . alts );
         self._reset(mark)
-        if (self.expect("|")) and (alts := self.alts()) and (self.expect("NEWLINE")):
-            return Rhs(alts.alts)
+        if (
+            (self.expect("|"))
+            and
+            (alts := self.alts())
+            and
+            (self.expect('NEWLINE'))
+        ):
+            return Rhs ( alts . alts );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def alt(self) -> Optional[Alt]:
         # alt: items '$' action | items '$' | items action | items
         mark = self._mark()
-        if (items := self.items()) and (self.expect("$")) and (action := self.action()):
-            return Alt(items + [NamedItem(None, NameLeaf("ENDMARKER"))], action=action)
+        if (
+            (items := self.items())
+            and
+            (self.expect('$'))
+            and
+            (action := self.action())
+        ):
+            return Alt ( items + [NamedItem ( None , NameLeaf ( 'ENDMARKER' ) )] , action = action );
         self._reset(mark)
-        if (items := self.items()) and (self.expect("$")):
-            return Alt(items + [NamedItem(None, NameLeaf("ENDMARKER"))], action=None)
+        if (
+            (items := self.items())
+            and
+            (self.expect('$'))
+        ):
+            return Alt ( items + [NamedItem ( None , NameLeaf ( 'ENDMARKER' ) )] , action = None );
         self._reset(mark)
-        if (items := self.items()) and (action := self.action()):
-            return Alt(items, action=action)
+        if (
+            (items := self.items())
+            and
+            (action := self.action())
+        ):
+            return Alt ( items , action = action );
         self._reset(mark)
-        if items := self.items():
-            return Alt(items, action=None)
+        if (
+            (items := self.items())
+        ):
+            return Alt ( items , action = None );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def items(self) -> Optional[NamedItemList]:
         # items: named_item items | named_item
         mark = self._mark()
-        if (named_item := self.named_item()) and (items := self.items()):
-            return [named_item] + items
+        if (
+            (named_item := self.named_item())
+            and
+            (items := self.items())
+        ):
+            return [named_item] + items;
         self._reset(mark)
-        if named_item := self.named_item():
-            return [named_item]
+        if (
+            (named_item := self.named_item())
+        ):
+            return [named_item];
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def named_item(self) -> Optional[NamedItem]:
@@ -236,119 +338,191 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (name := self.name())
-            and (annotation := self.annotation())
-            and (self.expect("="))
-            and (cut := True)
-            and (item := self.item())
+            and
+            (annotation := self.annotation())
+            and
+            (self.expect('='))
+            and
+            (cut := True)
+            and
+            (item := self.item())
         ):
-            return NamedItem(name.string, item, annotation)
+            return NamedItem ( name . string , item , annotation );
         self._reset(mark)
         if cut:
-            return None
+            return None;
         cut = False
         if (
             (name := self.name())
-            and (self.expect("="))
-            and (cut := True)
-            and (item := self.item())
+            and
+            (self.expect('='))
+            and
+            (cut := True)
+            and
+            (item := self.item())
         ):
-            return NamedItem(name.string, item)
+            return NamedItem ( name . string , item );
         self._reset(mark)
         if cut:
-            return None
-        if item := self.item():
-            return NamedItem(None, item)
+            return None;
+        if (
+            (item := self.item())
+        ):
+            return NamedItem ( None , item );
         self._reset(mark)
-        if it := self.forced_atom():
-            return NamedItem(None, it)
+        if (
+            (it := self.forced_atom())
+        ):
+            return NamedItem ( None , it );
         self._reset(mark)
-        if it := self.lookahead():
-            return NamedItem(None, it)
+        if (
+            (it := self.lookahead())
+        ):
+            return NamedItem ( None , it );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def forced_atom(self) -> Optional[LookaheadOrCut]:
         # forced_atom: '&' '&' ~ atom
         mark = self._mark()
         cut = False
-        if (self.expect("&")) and (self.expect("&")) and (cut := True) and (atom := self.atom()):
-            return Forced(atom)
+        if (
+            (self.expect('&'))
+            and
+            (self.expect('&'))
+            and
+            (cut := True)
+            and
+            (atom := self.atom())
+        ):
+            return Forced ( atom );
         self._reset(mark)
         if cut:
-            return None
-        return None
+            return None;
+        return None;
 
     @memoize
     def lookahead(self) -> Optional[LookaheadOrCut]:
         # lookahead: '&' ~ atom | '!' ~ atom | '~'
         mark = self._mark()
         cut = False
-        if (self.expect("&")) and (cut := True) and (atom := self.atom()):
-            return PositiveLookahead(atom)
+        if (
+            (self.expect('&'))
+            and
+            (cut := True)
+            and
+            (atom := self.atom())
+        ):
+            return PositiveLookahead ( atom );
         self._reset(mark)
         if cut:
-            return None
+            return None;
         cut = False
-        if (self.expect("!")) and (cut := True) and (atom := self.atom()):
-            return NegativeLookahead(atom)
+        if (
+            (self.expect('!'))
+            and
+            (cut := True)
+            and
+            (atom := self.atom())
+        ):
+            return NegativeLookahead ( atom );
         self._reset(mark)
         if cut:
-            return None
-        if self.expect("~"):
-            return Cut()
+            return None;
+        if (
+            (self.expect('~'))
+        ):
+            return Cut ( );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def item(self) -> Optional[Item]:
         # item: '[' ~ alts ']' | atom '?' | atom '*' | atom '+' | atom '.' atom '+' | atom
         mark = self._mark()
         cut = False
-        if (self.expect("[")) and (cut := True) and (alts := self.alts()) and (self.expect("]")):
-            return Opt(alts)
+        if (
+            (self.expect('['))
+            and
+            (cut := True)
+            and
+            (alts := self.alts())
+            and
+            (self.expect(']'))
+        ):
+            return Opt ( alts );
         self._reset(mark)
         if cut:
-            return None
-        if (atom := self.atom()) and (self.expect("?")):
-            return Opt(atom)
+            return None;
+        if (
+            (atom := self.atom())
+            and
+            (self.expect('?'))
+        ):
+            return Opt ( atom );
         self._reset(mark)
-        if (atom := self.atom()) and (self.expect("*")):
-            return Repeat0(atom)
+        if (
+            (atom := self.atom())
+            and
+            (self.expect('*'))
+        ):
+            return Repeat0 ( atom );
         self._reset(mark)
-        if (atom := self.atom()) and (self.expect("+")):
-            return Repeat1(atom)
+        if (
+            (atom := self.atom())
+            and
+            (self.expect('+'))
+        ):
+            return Repeat1 ( atom );
         self._reset(mark)
         if (
             (sep := self.atom())
-            and (self.expect("."))
-            and (node := self.atom())
-            and (self.expect("+"))
+            and
+            (self.expect('.'))
+            and
+            (node := self.atom())
+            and
+            (self.expect('+'))
         ):
-            return Gather(sep, node)
+            return Gather ( sep , node );
         self._reset(mark)
-        if atom := self.atom():
-            return atom
+        if (
+            (atom := self.atom())
+        ):
+            return atom;
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def atom(self) -> Optional[Plain]:
         # atom: '(' ~ alts ')' | NAME | STRING
         mark = self._mark()
         cut = False
-        if (self.expect("(")) and (cut := True) and (alts := self.alts()) and (self.expect(")")):
-            return Group(alts)
+        if (
+            (self.expect('('))
+            and
+            (cut := True)
+            and
+            (alts := self.alts())
+            and
+            (self.expect(')'))
+        ):
+            return Group ( alts );
         self._reset(mark)
         if cut:
-            return None
-        if name := self.name():
-            return NameLeaf(name.string)
+            return None;
+        if (
+            (name := self.name())
+        ):
+            return NameLeaf ( name . string );
         self._reset(mark)
-        if string := self.string():
-            return StringLeaf(string.string)
+        if (
+            (string := self.string())
+        ):
+            return StringLeaf ( string . string );
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def action(self) -> Optional[str]:
@@ -357,15 +531,18 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (self.expect("{"))
-            and (cut := True)
-            and (target_atoms := self.target_atoms())
-            and (self.expect("}"))
+            and
+            (cut := True)
+            and
+            (target_atoms := self.target_atoms())
+            and
+            (self.expect("}"))
         ):
-            return target_atoms
+            return target_atoms;
         self._reset(mark)
         if cut:
-            return None
-        return None
+            return None;
+        return None;
 
     @memoize
     def annotation(self) -> Optional[str]:
@@ -374,86 +551,164 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (self.expect("["))
-            and (cut := True)
-            and (target_atoms := self.target_atoms())
-            and (self.expect("]"))
+            and
+            (cut := True)
+            and
+            (target_atoms := self.target_atoms())
+            and
+            (self.expect("]"))
         ):
-            return target_atoms
+            return target_atoms;
         self._reset(mark)
         if cut:
-            return None
-        return None
+            return None;
+        return None;
 
     @memoize
     def target_atoms(self) -> Optional[str]:
         # target_atoms: target_atom target_atoms | target_atom
         mark = self._mark()
-        if (target_atom := self.target_atom()) and (target_atoms := self.target_atoms()):
-            return target_atom + " " + target_atoms
+        if (
+            (target_atom := self.target_atom())
+            and
+            (target_atoms := self.target_atoms())
+        ):
+            return target_atom + " " + target_atoms;
         self._reset(mark)
-        if target_atom := self.target_atom():
-            return target_atom
+        if (
+            (target_atom := self.target_atom())
+        ):
+            return target_atom;
         self._reset(mark)
-        return None
+        return None;
 
     @memoize
     def target_atom(self) -> Optional[str]:
-        # target_atom: "{" ~ target_atoms? "}" | "[" ~ target_atoms? "]" | NAME "*" | NAME | NUMBER | STRING | "?" | ":" | !"}" !"]" OP
+        # target_atom: "{" ~ target_atoms? "}" | "[" ~ target_atoms? "]" | NAME "*" | NAME | NUMBER | STRING | FSTRING_START target_fstring_middle* FSTRING_END | "?" | ":" | !"}" !"]" OP
         mark = self._mark()
         cut = False
         if (
             (self.expect("{"))
-            and (cut := True)
-            and (atoms := self.target_atoms(),)
-            and (self.expect("}"))
+            and
+            (cut := True)
+            and
+            (atoms := self.target_atoms(),)
+            and
+            (self.expect("}"))
         ):
-            return "{" + (atoms or "") + "}"
+            return "{" + ( atoms or "" ) + "}";
         self._reset(mark)
         if cut:
-            return None
+            return None;
         cut = False
         if (
             (self.expect("["))
-            and (cut := True)
-            and (atoms := self.target_atoms(),)
-            and (self.expect("]"))
+            and
+            (cut := True)
+            and
+            (atoms := self.target_atoms(),)
+            and
+            (self.expect("]"))
         ):
-            return "[" + (atoms or "") + "]"
+            return "[" + ( atoms or "" ) + "]";
         self._reset(mark)
         if cut:
-            return None
-        if (name := self.name()) and (self.expect("*")):
-            return name.string + "*"
+            return None;
+        if (
+            (name := self.name())
+            and
+            (self.expect("*"))
+        ):
+            return name . string + "*";
         self._reset(mark)
-        if name := self.name():
-            return name.string
+        if (
+            (name := self.name())
+        ):
+            return name . string;
         self._reset(mark)
-        if number := self.number():
-            return number.string
+        if (
+            (number := self.number())
+        ):
+            return number . string;
         self._reset(mark)
-        if string := self.string():
-            return string.string
+        if (
+            (string := self.string())
+        ):
+            return string . string;
         self._reset(mark)
-        if self.expect("?"):
-            return "?"
+        if (
+            (l := self.fstring_start())
+            and
+            (m := self._loop0_1(),)
+            and
+            (r := self.fstring_end())
+        ):
+            return l . string + '' . join ( m ) + r . string;
         self._reset(mark)
-        if self.expect(":"):
-            return ":"
+        if (
+            (self.expect("?"))
+        ):
+            return "?";
+        self._reset(mark)
+        if (
+            (self.expect(":"))
+        ):
+            return ":";
         self._reset(mark)
         if (
             (self.negative_lookahead(self.expect, "}"))
-            and (self.negative_lookahead(self.expect, "]"))
-            and (op := self.op())
+            and
+            (self.negative_lookahead(self.expect, "]"))
+            and
+            (op := self.op())
         ):
-            return op.string
+            return op . string;
         self._reset(mark)
-        return None
+        return None;
+
+    @memoize
+    def target_fstring_middle(self) -> Optional[str]:
+        # target_fstring_middle: FSTRING_MIDDLE | "{" | "}" | target_atom
+        mark = self._mark()
+        if (
+            (fstring_middle := self.fstring_middle())
+        ):
+            return fstring_middle . string;
+        self._reset(mark)
+        if (
+            (self.expect("{"))
+        ):
+            return "{";
+        self._reset(mark)
+        if (
+            (self.expect("}"))
+        ):
+            return "}";
+        self._reset(mark)
+        if (
+            (target_atom := self.target_atom())
+        ):
+            return target_atom;
+        self._reset(mark)
+        return None;
+
+    @memoize
+    def _loop0_1(self) -> Optional[Any]:
+        # _loop0_1: target_fstring_middle
+        mark = self._mark()
+        children = []
+        while (
+            (target_fstring_middle := self.target_fstring_middle())
+        ):
+            children.append(target_fstring_middle)
+            mark = self._mark()
+        self._reset(mark)
+        return children;
 
     KEYWORDS = ()
-    SOFT_KEYWORDS = ("memo",)
+    SOFT_KEYWORDS = ('memo',)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     from pegen.parser import simple_parser_main
-
     simple_parser_main(GeneratedParser)

--- a/src/pegen/grammar_parser.py
+++ b/src/pegen/grammar_parser.py
@@ -38,112 +38,78 @@ from pegen.grammar import (
     StringLeaf,
 )
 
+
 # Keywords and soft keywords are listed at the end of the parser definition.
 class GeneratedParser(Parser):
-
     @memoize
     def start(self) -> Optional[Grammar]:
         # start: grammar $
         mark = self._mark()
-        if (
-            (grammar := self.grammar())
-            and
-            (self.expect('ENDMARKER'))
-        ):
-            return grammar;
+        if (grammar := self.grammar()) and (self.expect("ENDMARKER")):
+            return grammar
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def grammar(self) -> Optional[Grammar]:
         # grammar: metas rules | rules
         mark = self._mark()
-        if (
-            (metas := self.metas())
-            and
-            (rules := self.rules())
-        ):
-            return Grammar ( rules , metas );
+        if (metas := self.metas()) and (rules := self.rules()):
+            return Grammar(rules, metas)
         self._reset(mark)
-        if (
-            (rules := self.rules())
-        ):
-            return Grammar ( rules , [] );
+        if rules := self.rules():
+            return Grammar(rules, [])
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def metas(self) -> Optional[MetaList]:
         # metas: meta metas | meta
         mark = self._mark()
-        if (
-            (meta := self.meta())
-            and
-            (metas := self.metas())
-        ):
-            return [meta] + metas;
+        if (meta := self.meta()) and (metas := self.metas()):
+            return [meta] + metas
         self._reset(mark)
-        if (
-            (meta := self.meta())
-        ):
-            return [meta];
+        if meta := self.meta():
+            return [meta]
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def meta(self) -> Optional[MetaTuple]:
         # meta: "@" NAME NEWLINE | "@" NAME NAME NEWLINE | "@" NAME STRING NEWLINE
         mark = self._mark()
-        if (
-            (self.expect("@"))
-            and
-            (name := self.name())
-            and
-            (self.expect('NEWLINE'))
-        ):
-            return ( name . string , None );
+        if (self.expect("@")) and (name := self.name()) and (self.expect("NEWLINE")):
+            return (name.string, None)
         self._reset(mark)
         if (
             (self.expect("@"))
-            and
-            (a := self.name())
-            and
-            (b := self.name())
-            and
-            (self.expect('NEWLINE'))
+            and (a := self.name())
+            and (b := self.name())
+            and (self.expect("NEWLINE"))
         ):
-            return ( a . string , b . string );
+            return (a.string, b.string)
         self._reset(mark)
         if (
             (self.expect("@"))
-            and
-            (name := self.name())
-            and
-            (string := self.string())
-            and
-            (self.expect('NEWLINE'))
+            and (name := self.name())
+            and (string := self.string())
+            and (self.expect("NEWLINE"))
         ):
-            return ( name . string , literal_eval ( string . string ) );
+            return (name.string, literal_eval(string.string))
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def rules(self) -> Optional[RuleList]:
         # rules: rule rules | rule
         mark = self._mark()
-        if (
-            (rule := self.rule())
-            and
-            (rules := self.rules())
-        ):
-            return [rule] + rules;
+        if (rule := self.rule()) and (rules := self.rules()):
+            return [rule] + rules
         self._reset(mark)
-        if (
-            (rule := self.rule())
-        ):
-            return [rule];
+        if rule := self.rule():
+            return [rule]
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def rule(self) -> Optional[Rule]:
@@ -151,107 +117,70 @@ class GeneratedParser(Parser):
         mark = self._mark()
         if (
             (rulename := self.rulename())
-            and
-            (opt := self.memoflag(),)
-            and
-            (self.expect(":"))
-            and
-            (alts := self.alts())
-            and
-            (self.expect('NEWLINE'))
-            and
-            (self.expect('INDENT'))
-            and
-            (more_alts := self.more_alts())
-            and
-            (self.expect('DEDENT'))
+            and (opt := self.memoflag(),)
+            and (self.expect(":"))
+            and (alts := self.alts())
+            and (self.expect("NEWLINE"))
+            and (self.expect("INDENT"))
+            and (more_alts := self.more_alts())
+            and (self.expect("DEDENT"))
         ):
-            return Rule ( rulename [0] , rulename [1] , Rhs ( alts . alts + more_alts . alts ) , memo = opt );
+            return Rule(rulename[0], rulename[1], Rhs(alts.alts + more_alts.alts), memo=opt)
         self._reset(mark)
         if (
             (rulename := self.rulename())
-            and
-            (opt := self.memoflag(),)
-            and
-            (self.expect(":"))
-            and
-            (self.expect('NEWLINE'))
-            and
-            (self.expect('INDENT'))
-            and
-            (more_alts := self.more_alts())
-            and
-            (self.expect('DEDENT'))
+            and (opt := self.memoflag(),)
+            and (self.expect(":"))
+            and (self.expect("NEWLINE"))
+            and (self.expect("INDENT"))
+            and (more_alts := self.more_alts())
+            and (self.expect("DEDENT"))
         ):
-            return Rule ( rulename [0] , rulename [1] , more_alts , memo = opt );
+            return Rule(rulename[0], rulename[1], more_alts, memo=opt)
         self._reset(mark)
         if (
             (rulename := self.rulename())
-            and
-            (opt := self.memoflag(),)
-            and
-            (self.expect(":"))
-            and
-            (alts := self.alts())
-            and
-            (self.expect('NEWLINE'))
+            and (opt := self.memoflag(),)
+            and (self.expect(":"))
+            and (alts := self.alts())
+            and (self.expect("NEWLINE"))
         ):
-            return Rule ( rulename [0] , rulename [1] , alts , memo = opt );
+            return Rule(rulename[0], rulename[1], alts, memo=opt)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def rulename(self) -> Optional[RuleName]:
         # rulename: NAME annotation | NAME
         mark = self._mark()
-        if (
-            (name := self.name())
-            and
-            (annotation := self.annotation())
-        ):
-            return ( name . string , annotation );
+        if (name := self.name()) and (annotation := self.annotation()):
+            return (name.string, annotation)
         self._reset(mark)
-        if (
-            (name := self.name())
-        ):
-            return ( name . string , None );
+        if name := self.name():
+            return (name.string, None)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def memoflag(self) -> Optional[str]:
         # memoflag: '(' "memo" ')'
         mark = self._mark()
-        if (
-            (self.expect('('))
-            and
-            (self.expect("memo"))
-            and
-            (self.expect(')'))
-        ):
-            return "memo";
+        if (self.expect("(")) and (self.expect("memo")) and (self.expect(")")):
+            return "memo"
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def alts(self) -> Optional[Rhs]:
         # alts: alt "|" alts | alt
         mark = self._mark()
-        if (
-            (alt := self.alt())
-            and
-            (self.expect("|"))
-            and
-            (alts := self.alts())
-        ):
-            return Rhs ( [alt] + alts . alts );
+        if (alt := self.alt()) and (self.expect("|")) and (alts := self.alts()):
+            return Rhs([alt] + alts.alts)
         self._reset(mark)
-        if (
-            (alt := self.alt())
-        ):
-            return Rhs ( [alt] );
+        if alt := self.alt():
+            return Rhs([alt])
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def more_alts(self) -> Optional[Rhs]:
@@ -259,77 +188,46 @@ class GeneratedParser(Parser):
         mark = self._mark()
         if (
             (self.expect("|"))
-            and
-            (alts := self.alts())
-            and
-            (self.expect('NEWLINE'))
-            and
-            (more_alts := self.more_alts())
+            and (alts := self.alts())
+            and (self.expect("NEWLINE"))
+            and (more_alts := self.more_alts())
         ):
-            return Rhs ( alts . alts + more_alts . alts );
+            return Rhs(alts.alts + more_alts.alts)
         self._reset(mark)
-        if (
-            (self.expect("|"))
-            and
-            (alts := self.alts())
-            and
-            (self.expect('NEWLINE'))
-        ):
-            return Rhs ( alts . alts );
+        if (self.expect("|")) and (alts := self.alts()) and (self.expect("NEWLINE")):
+            return Rhs(alts.alts)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def alt(self) -> Optional[Alt]:
         # alt: items '$' action | items '$' | items action | items
         mark = self._mark()
-        if (
-            (items := self.items())
-            and
-            (self.expect('$'))
-            and
-            (action := self.action())
-        ):
-            return Alt ( items + [NamedItem ( None , NameLeaf ( 'ENDMARKER' ) )] , action = action );
+        if (items := self.items()) and (self.expect("$")) and (action := self.action()):
+            return Alt(items + [NamedItem(None, NameLeaf("ENDMARKER"))], action=action)
         self._reset(mark)
-        if (
-            (items := self.items())
-            and
-            (self.expect('$'))
-        ):
-            return Alt ( items + [NamedItem ( None , NameLeaf ( 'ENDMARKER' ) )] , action = None );
+        if (items := self.items()) and (self.expect("$")):
+            return Alt(items + [NamedItem(None, NameLeaf("ENDMARKER"))], action=None)
         self._reset(mark)
-        if (
-            (items := self.items())
-            and
-            (action := self.action())
-        ):
-            return Alt ( items , action = action );
+        if (items := self.items()) and (action := self.action()):
+            return Alt(items, action=action)
         self._reset(mark)
-        if (
-            (items := self.items())
-        ):
-            return Alt ( items , action = None );
+        if items := self.items():
+            return Alt(items, action=None)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def items(self) -> Optional[NamedItemList]:
         # items: named_item items | named_item
         mark = self._mark()
-        if (
-            (named_item := self.named_item())
-            and
-            (items := self.items())
-        ):
-            return [named_item] + items;
+        if (named_item := self.named_item()) and (items := self.items()):
+            return [named_item] + items
         self._reset(mark)
-        if (
-            (named_item := self.named_item())
-        ):
-            return [named_item];
+        if named_item := self.named_item():
+            return [named_item]
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def named_item(self) -> Optional[NamedItem]:
@@ -338,191 +236,119 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (name := self.name())
-            and
-            (annotation := self.annotation())
-            and
-            (self.expect('='))
-            and
-            (cut := True)
-            and
-            (item := self.item())
+            and (annotation := self.annotation())
+            and (self.expect("="))
+            and (cut := True)
+            and (item := self.item())
         ):
-            return NamedItem ( name . string , item , annotation );
+            return NamedItem(name.string, item, annotation)
         self._reset(mark)
         if cut:
-            return None;
+            return None
         cut = False
         if (
             (name := self.name())
-            and
-            (self.expect('='))
-            and
-            (cut := True)
-            and
-            (item := self.item())
+            and (self.expect("="))
+            and (cut := True)
+            and (item := self.item())
         ):
-            return NamedItem ( name . string , item );
+            return NamedItem(name.string, item)
         self._reset(mark)
         if cut:
-            return None;
-        if (
-            (item := self.item())
-        ):
-            return NamedItem ( None , item );
+            return None
+        if item := self.item():
+            return NamedItem(None, item)
         self._reset(mark)
-        if (
-            (it := self.forced_atom())
-        ):
-            return NamedItem ( None , it );
+        if it := self.forced_atom():
+            return NamedItem(None, it)
         self._reset(mark)
-        if (
-            (it := self.lookahead())
-        ):
-            return NamedItem ( None , it );
+        if it := self.lookahead():
+            return NamedItem(None, it)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def forced_atom(self) -> Optional[LookaheadOrCut]:
         # forced_atom: '&' '&' ~ atom
         mark = self._mark()
         cut = False
-        if (
-            (self.expect('&'))
-            and
-            (self.expect('&'))
-            and
-            (cut := True)
-            and
-            (atom := self.atom())
-        ):
-            return Forced ( atom );
+        if (self.expect("&")) and (self.expect("&")) and (cut := True) and (atom := self.atom()):
+            return Forced(atom)
         self._reset(mark)
         if cut:
-            return None;
-        return None;
+            return None
+        return None
 
     @memoize
     def lookahead(self) -> Optional[LookaheadOrCut]:
         # lookahead: '&' ~ atom | '!' ~ atom | '~'
         mark = self._mark()
         cut = False
-        if (
-            (self.expect('&'))
-            and
-            (cut := True)
-            and
-            (atom := self.atom())
-        ):
-            return PositiveLookahead ( atom );
+        if (self.expect("&")) and (cut := True) and (atom := self.atom()):
+            return PositiveLookahead(atom)
         self._reset(mark)
         if cut:
-            return None;
+            return None
         cut = False
-        if (
-            (self.expect('!'))
-            and
-            (cut := True)
-            and
-            (atom := self.atom())
-        ):
-            return NegativeLookahead ( atom );
+        if (self.expect("!")) and (cut := True) and (atom := self.atom()):
+            return NegativeLookahead(atom)
         self._reset(mark)
         if cut:
-            return None;
-        if (
-            (self.expect('~'))
-        ):
-            return Cut ( );
+            return None
+        if self.expect("~"):
+            return Cut()
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def item(self) -> Optional[Item]:
         # item: '[' ~ alts ']' | atom '?' | atom '*' | atom '+' | atom '.' atom '+' | atom
         mark = self._mark()
         cut = False
-        if (
-            (self.expect('['))
-            and
-            (cut := True)
-            and
-            (alts := self.alts())
-            and
-            (self.expect(']'))
-        ):
-            return Opt ( alts );
+        if (self.expect("[")) and (cut := True) and (alts := self.alts()) and (self.expect("]")):
+            return Opt(alts)
         self._reset(mark)
         if cut:
-            return None;
-        if (
-            (atom := self.atom())
-            and
-            (self.expect('?'))
-        ):
-            return Opt ( atom );
+            return None
+        if (atom := self.atom()) and (self.expect("?")):
+            return Opt(atom)
         self._reset(mark)
-        if (
-            (atom := self.atom())
-            and
-            (self.expect('*'))
-        ):
-            return Repeat0 ( atom );
+        if (atom := self.atom()) and (self.expect("*")):
+            return Repeat0(atom)
         self._reset(mark)
-        if (
-            (atom := self.atom())
-            and
-            (self.expect('+'))
-        ):
-            return Repeat1 ( atom );
+        if (atom := self.atom()) and (self.expect("+")):
+            return Repeat1(atom)
         self._reset(mark)
         if (
             (sep := self.atom())
-            and
-            (self.expect('.'))
-            and
-            (node := self.atom())
-            and
-            (self.expect('+'))
+            and (self.expect("."))
+            and (node := self.atom())
+            and (self.expect("+"))
         ):
-            return Gather ( sep , node );
+            return Gather(sep, node)
         self._reset(mark)
-        if (
-            (atom := self.atom())
-        ):
-            return atom;
+        if atom := self.atom():
+            return atom
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def atom(self) -> Optional[Plain]:
         # atom: '(' ~ alts ')' | NAME | STRING
         mark = self._mark()
         cut = False
-        if (
-            (self.expect('('))
-            and
-            (cut := True)
-            and
-            (alts := self.alts())
-            and
-            (self.expect(')'))
-        ):
-            return Group ( alts );
+        if (self.expect("(")) and (cut := True) and (alts := self.alts()) and (self.expect(")")):
+            return Group(alts)
         self._reset(mark)
         if cut:
-            return None;
-        if (
-            (name := self.name())
-        ):
-            return NameLeaf ( name . string );
+            return None
+        if name := self.name():
+            return NameLeaf(name.string)
         self._reset(mark)
-        if (
-            (string := self.string())
-        ):
-            return StringLeaf ( string . string );
+        if string := self.string():
+            return StringLeaf(string.string)
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def action(self) -> Optional[str]:
@@ -531,18 +357,15 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (self.expect("{"))
-            and
-            (cut := True)
-            and
-            (target_atoms := self.target_atoms())
-            and
-            (self.expect("}"))
+            and (cut := True)
+            and (target_atoms := self.target_atoms())
+            and (self.expect("}"))
         ):
-            return target_atoms;
+            return target_atoms
         self._reset(mark)
         if cut:
-            return None;
-        return None;
+            return None
+        return None
 
     @memoize
     def annotation(self) -> Optional[str]:
@@ -551,36 +374,27 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (self.expect("["))
-            and
-            (cut := True)
-            and
-            (target_atoms := self.target_atoms())
-            and
-            (self.expect("]"))
+            and (cut := True)
+            and (target_atoms := self.target_atoms())
+            and (self.expect("]"))
         ):
-            return target_atoms;
+            return target_atoms
         self._reset(mark)
         if cut:
-            return None;
-        return None;
+            return None
+        return None
 
     @memoize
     def target_atoms(self) -> Optional[str]:
         # target_atoms: target_atom target_atoms | target_atom
         mark = self._mark()
-        if (
-            (target_atom := self.target_atom())
-            and
-            (target_atoms := self.target_atoms())
-        ):
-            return target_atom + " " + target_atoms;
+        if (target_atom := self.target_atom()) and (target_atoms := self.target_atoms()):
+            return target_atom + " " + target_atoms
         self._reset(mark)
-        if (
-            (target_atom := self.target_atom())
-        ):
-            return target_atom;
+        if target_atom := self.target_atom():
+            return target_atom
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def target_atom(self) -> Optional[str]:
@@ -589,126 +403,89 @@ class GeneratedParser(Parser):
         cut = False
         if (
             (self.expect("{"))
-            and
-            (cut := True)
-            and
-            (atoms := self.target_atoms(),)
-            and
-            (self.expect("}"))
+            and (cut := True)
+            and (atoms := self.target_atoms(),)
+            and (self.expect("}"))
         ):
-            return "{" + ( atoms or "" ) + "}";
+            return "{" + (atoms or "") + "}"
         self._reset(mark)
         if cut:
-            return None;
+            return None
         cut = False
         if (
             (self.expect("["))
-            and
-            (cut := True)
-            and
-            (atoms := self.target_atoms(),)
-            and
-            (self.expect("]"))
+            and (cut := True)
+            and (atoms := self.target_atoms(),)
+            and (self.expect("]"))
         ):
-            return "[" + ( atoms or "" ) + "]";
+            return "[" + (atoms or "") + "]"
         self._reset(mark)
         if cut:
-            return None;
-        if (
-            (name := self.name())
-            and
-            (self.expect("*"))
-        ):
-            return name . string + "*";
+            return None
+        if (name := self.name()) and (self.expect("*")):
+            return name.string + "*"
         self._reset(mark)
-        if (
-            (name := self.name())
-        ):
-            return name . string;
+        if name := self.name():
+            return name.string
         self._reset(mark)
-        if (
-            (number := self.number())
-        ):
-            return number . string;
+        if number := self.number():
+            return number.string
         self._reset(mark)
-        if (
-            (string := self.string())
-        ):
-            return string . string;
+        if string := self.string():
+            return string.string
         self._reset(mark)
-        if (
-            (l := self.fstring_start())
-            and
-            (m := self._loop0_1(),)
-            and
-            (r := self.fstring_end())
-        ):
-            return l . string + '' . join ( m ) + r . string;
+        if (l := self.fstring_start()) and (m := self._loop0_1(),) and (r := self.fstring_end()):
+            return l.string + "".join(m) + r.string
         self._reset(mark)
-        if (
-            (self.expect("?"))
-        ):
-            return "?";
+        if self.expect("?"):
+            return "?"
         self._reset(mark)
-        if (
-            (self.expect(":"))
-        ):
-            return ":";
+        if self.expect(":"):
+            return ":"
         self._reset(mark)
         if (
             (self.negative_lookahead(self.expect, "}"))
-            and
-            (self.negative_lookahead(self.expect, "]"))
-            and
-            (op := self.op())
+            and (self.negative_lookahead(self.expect, "]"))
+            and (op := self.op())
         ):
-            return op . string;
+            return op.string
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def target_fstring_middle(self) -> Optional[str]:
         # target_fstring_middle: FSTRING_MIDDLE | "{" | "}" | target_atom
         mark = self._mark()
-        if (
-            (fstring_middle := self.fstring_middle())
-        ):
-            return fstring_middle . string;
+        if fstring_middle := self.fstring_middle():
+            return fstring_middle.string
         self._reset(mark)
-        if (
-            (self.expect("{"))
-        ):
-            return "{";
+        if self.expect("{"):
+            return "{"
         self._reset(mark)
-        if (
-            (self.expect("}"))
-        ):
-            return "}";
+        if self.expect("}"):
+            return "}"
         self._reset(mark)
-        if (
-            (target_atom := self.target_atom())
-        ):
-            return target_atom;
+        if target_atom := self.target_atom():
+            return target_atom
         self._reset(mark)
-        return None;
+        return None
 
     @memoize
     def _loop0_1(self) -> Optional[Any]:
         # _loop0_1: target_fstring_middle
         mark = self._mark()
         children = []
-        while (
-            (target_fstring_middle := self.target_fstring_middle())
-        ):
+        while target_fstring_middle := self.target_fstring_middle():
             children.append(target_fstring_middle)
             mark = self._mark()
         self._reset(mark)
-        return children;
+        return children
 
     KEYWORDS = ()
-    SOFT_KEYWORDS = ('memo',)
+    SOFT_KEYWORDS = ("memo",)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from pegen.parser import simple_parser_main
+
     simple_parser_main(GeneratedParser)

--- a/src/pegen/metagrammar.gram
+++ b/src/pegen/metagrammar.gram
@@ -126,6 +126,13 @@ target_atom[str]:
     | NAME { name.string }
     | NUMBER { number.string }
     | STRING { string.string }
+    | l=FSTRING_START m=target_fstring_middle* r=FSTRING_END { l.string + ''.join(m) + r.string }
     | "?" { "?" }
     | ":" { ":" }
     | !"}" !"]" OP { op.string }
+
+target_fstring_middle[str]:
+    | FSTRING_MIDDLE { fstring_middle.string }
+    | "{" { "{" }
+    | "}" { "}" }
+    | target_atom { target_atom }

--- a/src/pegen/metagrammar.gram
+++ b/src/pegen/metagrammar.gram
@@ -126,7 +126,7 @@ target_atom[str]:
     | NAME { name.string }
     | NUMBER { number.string }
     | STRING { string.string }
-    | l=FSTRING_START m=target_fstring_middle* r=FSTRING_END { l.string + ''.join(m) + r.string }
+    | l=FSTRING_START m=target_fstring_middle* r=FSTRING_END { l.string + "".join(m) + r.string }
     | "?" { "?" }
     | ":" { ":" }
     | !"}" !"]" OP { op.string }

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -14,6 +14,10 @@ T = TypeVar("T")
 P = TypeVar("P", bound="Parser")
 F = TypeVar("F", bound=Callable[..., Any])
 
+# Tokens added in Python 3.12
+FSTRING_START = getattr(token, 'FSTRING_START', None)
+FSTRING_MIDDLE = getattr(token, 'FSTRING_MIDDLE', None)
+FSTRING_END = getattr(token, 'FSTRING_END', None)
 
 def logger(method: F) -> F:
     """For non-memoized functions that we want to be logged.
@@ -213,6 +217,27 @@ class Parser(ABC):
     def string(self) -> Optional[tokenize.TokenInfo]:
         tok = self._tokenizer.peek()
         if tok.type == token.STRING:
+            return self._tokenizer.getnext()
+        return None
+
+    @memoize
+    def fstring_start(self) -> Optional[tokenize.TokenInfo]:
+        tok = self._tokenizer.peek()
+        if tok.type == FSTRING_START:
+            return self._tokenizer.getnext()
+        return None
+
+    @memoize
+    def fstring_middle(self) -> Optional[tokenize.TokenInfo]:
+        tok = self._tokenizer.peek()
+        if tok.type == FSTRING_MIDDLE:
+            return self._tokenizer.getnext()
+        return None
+
+    @memoize
+    def fstring_end(self) -> Optional[tokenize.TokenInfo]:
+        tok = self._tokenizer.peek()
+        if tok.type == FSTRING_END:
             return self._tokenizer.getnext()
         return None
 

--- a/src/pegen/parser.py
+++ b/src/pegen/parser.py
@@ -15,9 +15,10 @@ P = TypeVar("P", bound="Parser")
 F = TypeVar("F", bound=Callable[..., Any])
 
 # Tokens added in Python 3.12
-FSTRING_START = getattr(token, 'FSTRING_START', None)
-FSTRING_MIDDLE = getattr(token, 'FSTRING_MIDDLE', None)
-FSTRING_END = getattr(token, 'FSTRING_END', None)
+FSTRING_START = getattr(token, "FSTRING_START", None)
+FSTRING_MIDDLE = getattr(token, "FSTRING_MIDDLE", None)
+FSTRING_END = getattr(token, "FSTRING_END", None)
+
 
 def logger(method: F) -> F:
     """For non-memoized functions that we want to be logged.

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -233,6 +233,9 @@ class PythonParserGenerator(ParserGenerator, GrammarVisitor):
         unreachable_formatting: Optional[str] = None,
     ):
         tokens.add("SOFT_KEYWORD")
+        tokens.update(
+            ["FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END"]
+        )  # used in metagrammar to support Python 3.12 f-strings; don't exist in 3.11
         super().__init__(grammar, tokens, file)
         self.callmakervisitor: PythonCallMakerVisitor = PythonCallMakerVisitor(self)
         self.invalidvisitor: InvalidNodeVisitor = InvalidNodeVisitor()

--- a/src/pegen/python_generator.py
+++ b/src/pegen/python_generator.py
@@ -102,7 +102,16 @@ class PythonCallMakerVisitor(GrammarVisitor):
         name = node.value
         if name == "SOFT_KEYWORD":
             return "soft_keyword", "self.soft_keyword()"
-        if name in ("NAME", "NUMBER", "STRING", "OP", "TYPE_COMMENT"):
+        if name in (
+            "NAME",
+            "NUMBER",
+            "STRING",
+            "FSTRING_START",
+            "FSTRING_MIDDLE",
+            "FSTRING_END",
+            "OP",
+            "TYPE_COMMENT",
+        ):
             name = name.lower()
             return name, f"self.{name}()"
         if name in ("NEWLINE", "DEDENT", "INDENT", "ENDMARKER", "ASYNC", "AWAIT"):


### PR DESCRIPTION
As pointed out in #93, in Python 3.12 the PEP 701 changes to f-string tokenization cause Pegen to fail on grammars which contain f-strings in their actions (such as the Python grammar). This PR adds support for the new tokens to Pegen and changes the metagrammar to restore f-string support under 3.12 (while preserving support under older versions of Python).

Two things this PR does not currently do:
- Fix broken tests under 3.12. I'm getting 28 failures currently, but as far as I can tell they don't have to do with the changes in this PR and are rather caused by other differences in the 3.12 tokenizer/parser. I can try to fix these later, but any help would be appreciated!
- Update the example Python grammar (`data/python.gram`) for 3.12.