### PR TITLE
Added fstring Test Case and Potential Fix

### DIFF
--- a/data/python.gram
+++ b/data/python.gram
@@ -1696,7 +1696,7 @@ fstring_full_format_spec:
         )
      }
 fstring_format_spec:
-    | t=FSTRING_MIDDLE { ast.Constant(value=t.string.encode(), LOCATIONS) }
+    | t=FSTRING_MIDDLE { ast.Constant(value=t.string, LOCATIONS) }
     | fstring_replacement_field
 fstring:
     | a=FSTRING_START b=fstring_mid* c=FSTRING_END {

--- a/tests/python_parser/data/fstrings.py
+++ b/tests/python_parser/data/fstrings.py
@@ -65,3 +65,6 @@ x = (
 
 
 f'{expr:}'
+
+foo = 3.14159
+verbosePrint(f'Foo {foo:.3} bar.')


### PR DESCRIPTION
There seems to be an fstring case that is incorrect with the current Python grammar. I've added a case to fstrings.py to highlight the behavior. I think the issue is an unnecessary encode in the `fstring_format_spec` rule, so I removed that, but I'm not sure if that has other implications so I would appreciate any feedback.