### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8','3.9','3.10', '3.11', '3.12']
+        python-version: ['3.8','3.9','3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Get history and tags for SCM versioning to work

--- a/data/python.gram
+++ b/data/python.gram
@@ -2354,7 +2354,7 @@ invalid_while_stmt[NoReturn]:
         )
      }
 invalid_for_stmt[NoReturn]:
-    | [ASYNC] 'for' star_targets 'in' star_expressions NEWLINE { self.raise_syntax_error("expected ':'") }
+    | ['async'] 'for' star_targets 'in' star_expressions NEWLINE { self.raise_syntax_error("expected ':'") }
     | ['async'] a='for' star_targets 'in' star_expressions ':' NEWLINE !INDENT {
         self.raise_indentation_error(
             f"expected an indented block after 'for' statement on line {a.start[0]}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3 :: Only",
 ]
 keywords = ["parser", "CPython", "PEG", "pegen"]


### PR DESCRIPTION
This PR makes the test suite pass under Python 3.13: the only change required is removing a use of the `ASYNC` token in `data/python.gram` (that token no longer exists in Python 3.13). While I was at it I added 3.13 to the CI matrix and updated the Trove classifiers to declare support for Python 3.8-3.13.

I have not fixed the corresponding issue in `data/fullpy.gram` as that grammar has other issues preventing it from working anyway. Nor have I removed `ASYNC` or `AWAIT` from `data/Tokens` since those tokens could still be created when using older versions of Python (and as far as I can tell the file is not used by anything except a broken part of the `show_parse.py` script).