### PR TITLE
Remove broken links from documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,10 +67,6 @@ Indices and tables
    peg_parsers
    grammar
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
-
 Developing
 ----------
 


### PR DESCRIPTION
This removes three broken links from the documentation:
- The genindex is currently empty, because we do not use any index directives.
- The modindex is not generated at all and the link is invalid, because no python modules are documented (f.e. with sphinx.ext.autodoc).
- The search page does not need to be linked from the index. If you click on the link you will only get a blank page. The search is triggered with the input field in the sidebar.