### PR TITLE
Handle multi-line pattern matching expression

### DIFF
--- a/src/pegen/tokenizer.py
+++ b/src/pegen/tokenizer.py
@@ -28,6 +28,7 @@ class Tokenizer:
         self._verbose = verbose
         self._lines: Dict[int, str] = {}
         self._path = path
+        self._in_match = 0
         if verbose:
             self.report(False, False)
 
@@ -55,6 +56,11 @@ class Tokenizer:
             ):
                 continue
             self._tokens.append(tok)
+            if tok.type == tokenize.NAME and tok.string == "pmatch":
+                self._in_match += 1
+            if self._in_match and tok.type == tokenize.DEDENT:
+                self._in_match -= 1
+                self._tokens.append(tokenize.TokenInfo(tokenize.NEWLINE, "\n", tok.start, tok.end, "\n"))
             if not self._path and tok.start[0] not in self._lines:
                 self._lines[tok.start[0]] = tok.line
         return self._tokens[self._index]
@@ -116,3 +122,4 @@ class Tokenizer:
         else:
             tok = self._tokens[self._index - 1]
             print(f"{fill} {shorttok(tok)}")
+

--- a/tests/test_pegen.py
+++ b/tests/test_pegen.py
@@ -694,3 +694,26 @@ def test_keywords() -> None:
     parser_class = make_parser(grammar)
     assert parser_class.KEYWORDS == ("five", "four", "one", "three", "two")
     assert parser_class.SOFT_KEYWORDS == ("eight", "nine", "seven", "six", "ten")
+
+def test_pmatch() -> None:
+    grammar_source = """
+    start: expr NEWLINE
+    expr: ('-' term | expr '+' term | term | match_expr)
+    term: NUMBER | NAME | STRING
+    match_expr: 'pmatch' expr ':' NEWLINE INDENT blocks=match_block+ DEDENT
+    match_block: expr ':' expr NEWLINE
+    """
+    parser_class = make_parser(grammar_source)
+    source = """
+    # Proposed match_expr using the keyword pmatch
+    pmatch num:
+        1: "One"
+        2: "Two"
+        3: pmatch num2:
+            1: "One"
+            2: "Two"
+            3: "Three"
+        _: "Number not between 1 and 3"
+    """
+    node = parse_string(source, parser_class)
+    assert node


### PR DESCRIPTION
This is necessary to support an alternative python syntax.

```
# Proposed match_expr using the keyword pmatch
def test(num, num2):
    a = pmatch num:
        1: "One"
        2: "Two"
        3: pmatch num2:
           1: "One"
           2: "Two"
           3: "Three"
        _: "Number not between 1 and 3"
    return a
 ```

Details in the issue. Solution implemented handles it similar to how python's builtin tokenizer handles multi-line expressions involving parens.

Fixes #107 
